### PR TITLE
fix(ui): restore disclosure panel borders

### DIFF
--- a/packages/registry/registry/default/ui/disclosure.ts
+++ b/packages/registry/registry/default/ui/disclosure.ts
@@ -13,7 +13,7 @@ export const disclosurePanelClass =
   'overflow-hidden rounded-b-lg border border-t-0 border-border bg-card px-4 py-3 text-sm text-muted-foreground'
 
 export const disclosureAnimatedPanelClass =
-  'overflow-hidden border-t border-border text-sm text-muted-foreground'
+  'overflow-hidden rounded-b-lg border-x border-b border-t-0 border-border bg-card px-4 py-3 text-sm text-muted-foreground'
 
 export const disclosureChevronClass =
   'size-4 shrink-0 text-muted-foreground transition-transform duration-200'


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Restore borders and background styling to disclosure animated panel
Updates `disclosureAnimatedPanelClass` in [disclosure.ts](https://github.com/elianiva/foldcn/pull/1/files#diff-8a3e3e0fb9e1e305eac7d6238ce7fcdfcebd8d27fbc8ebab8d06c20ad94cf457) to add side and bottom borders, remove the top border, apply rounded bottom corners, and add a card background with padding.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized e576f4b.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->