### PR TITLE
fix(ui): Switch things

### DIFF
--- a/packages/registry/registry/default/ui/disclosure.ts
+++ b/packages/registry/registry/default/ui/disclosure.ts
@@ -13,7 +13,7 @@ export const disclosurePanelClass =
   'overflow-hidden rounded-b-lg border border-t-0 border-border bg-card px-4 py-3 text-sm text-muted-foreground'
 
 export const disclosureAnimatedPanelClass =
-  'overflow-hidden border-t border-border text-sm text-muted-foreground'
+  'overflow-hidden rounded-b-lg border-x border-b border-t-0 border-border bg-card px-4 py-3 text-sm text-muted-foreground'
 
 export const disclosureChevronClass =
   'size-4 shrink-0 text-muted-foreground transition-transform duration-200'

--- a/packages/registry/registry/default/ui/switch.ts
+++ b/packages/registry/registry/default/ui/switch.ts
@@ -4,13 +4,10 @@ import type { Html, HtmlBuilder } from 'foldkit/html'
 import { cn } from '@/lib/utils'
 
 export const switchClass =
-  'peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80'
+  'peer group/switch inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-input shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[checked]:bg-primary dark:bg-input/80'
 
 export const switchThumbClass =
-  'pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground'
-
-const switchThumbOn = 'translate-x-4'
-const switchThumbOff = 'translate-x-0'
+  'pointer-events-none block size-4 rounded-full bg-background ring-0 transition-transform group-data-[checked]/switch:translate-x-4 group-data-[unchecked]/switch:translate-x-0 dark:group-data-[checked]/switch:bg-primary-foreground dark:group-data-[unchecked]/switch:bg-foreground'
 
 export const switchLabelClass =
   'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
@@ -61,7 +58,6 @@ export const switch_ = <M>(config: SwitchConfig<M>, h: HtmlBuilder<M>): Html =>
                   h.Class(
                     cn(
                       switchThumbClass,
-                      config.isChecked ? switchThumbOn : switchThumbOff,
                       config.thumbClass,
                     ),
                   ),

--- a/packages/registry/registry/default/ui/switch.ts
+++ b/packages/registry/registry/default/ui/switch.ts
@@ -3,11 +3,26 @@ import type { Html, HtmlBuilder } from 'foldkit/html'
 
 import { cn } from '@/lib/utils'
 
-export const switchClass =
-  'peer group/switch inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-input shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[checked]:bg-primary dark:bg-input/80'
+export const switchSizeKeys = ['default', 'sm'] as const
+export type SwitchSize = (typeof switchSizeKeys)[number]
+
+export const switchSizes: Record<SwitchSize, string> = {
+  default: 'h-5 w-9',
+  sm: 'h-3.5 w-6',
+}
+
+const switchBase =
+  'peer group/switch inline-flex shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-input shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[checked]:bg-primary dark:bg-input/80'
+
+export const switchClass = switchBase
 
 export const switchThumbClass =
-  'pointer-events-none block size-4 rounded-full bg-background ring-0 transition-transform group-data-[checked]/switch:translate-x-4 group-data-[unchecked]/switch:translate-x-0 dark:group-data-[checked]/switch:bg-primary-foreground dark:group-data-[unchecked]/switch:bg-foreground'
+  'pointer-events-none block rounded-full bg-background ring-0 transition-transform dark:group-data-[checked]/switch:bg-primary-foreground dark:group-data-[unchecked]/switch:bg-foreground'
+
+export const switchThumbSizes: Record<SwitchSize, string> = {
+  default: 'size-4 group-data-[checked]/switch:translate-x-4',
+  sm: 'size-3 group-data-[checked]/switch:translate-x-3',
+}
 
 export const switchLabelClass =
   'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
@@ -28,6 +43,7 @@ export type SwitchConfig<M> = Readonly<{
   isReadOnly?: boolean
   name?: string
   value?: string
+  size?: SwitchSize
   className?: string
   thumbClass?: string
   labelClass?: string
@@ -52,12 +68,17 @@ export const switch_ = <M>(config: SwitchConfig<M>, h: HtmlBuilder<M>): Html =>
           [h.Class(cn(switchWrapperClass, config.wrapperClass))],
           [
             h.button(
-              [...attributes.button, h.Class(cn(switchClass, config.className))],
+              [
+                ...attributes.button,
+                h.Class(cn(switchClass, switchSizes[config.size ?? 'default'], config.className)),
+                h.DataAttribute('size', config.size ?? 'default'),
+              ],
               [
                 h.span([
                   h.Class(
                     cn(
                       switchThumbClass,
+                      switchThumbSizes[config.size ?? 'default'],
                       config.thumbClass,
                     ),
                   ),


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Restore disclosure panel borders and refactor switch sizing in UI registry
- Refactors switch sizing in [switch.ts](https://github.com/elianiva/foldcn/pull/3/files#diff-e0424ee27a800e64b32f211a8707b4d11c1b522b9a93a8808f43730e779bce55) to use explicit size keys (`default`, `sm`) with corresponding Tailwind classes, replacing the previous monolithic class string.
- Switch background is now controlled via `data-[checked]` instead of `data-[state]`, and thumb movement uses CSS group data attributes instead of inline conditional logic.
- Behavioral Change: Default switch dimensions change from `h-[1.15rem] w-8` to `h-5 w-9`, and the thumb grows from implicit sizing to `size-4` with `translate-x-4` on checked.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63f2168.</sup>
<!-- Macroscope's review summary ends here -->
<!-- Macroscope's pull request summary ends here -->