### PR TITLE
fix(demo): swap avatar fallback on image load error

### DIFF
--- a/packages/web/src/demo/assemble.ts
+++ b/packages/web/src/demo/assemble.ts
@@ -281,6 +281,7 @@ export const update = (model: Model, message: Message): UpdateReturn =>
       ...accordionSlice.handlers(model),
       ...alertDialogSlice.handlers(model),
       ...animationSlice.handlers(model),
+      ...avatarSlice.handlers(model),
       ...buttonSlice.handlers(model),
       ...calendarSlice.handlers(model),
       ...cardSlice.handlers(model),

--- a/packages/web/src/demo/views/avatar.ts
+++ b/packages/web/src/demo/views/avatar.ts
@@ -1,71 +1,99 @@
+import { Schema as S } from 'effect'
+import { evo } from 'foldkit/struct'
+import { defineMessageUnion } from 'foldkit/message'
 import type { Html, HtmlBuilder } from 'foldkit/html'
 
-import { Avatar } from '@foldcn/registry/styles/default/ui/avatar'
+import { cn } from '@/lib/utils'
+import { Avatar, avatarImageClass } from '@foldcn/registry/styles/default/ui/avatar'
 
-import { defineSlice } from '../slice'
-import type { Model, Message } from '../assemble'
+import { defineSlice, type UpdateReturn } from '../slice'
+import type { Model, Message as AppMessage } from '../assemble'
 
-export const avatarView = (model: Model, h: HtmlBuilder<Message>): Html =>
+const Message = defineMessageUnion({
+  AvatarImageErrored: { key: S.String },
+})
+
+/**
+ * foldkit's `Avatar.image` always renders an `<img>` — it never auto-swaps
+ * to the fallback on load error (see the registry component's doc comment).
+ * This wires that swap up ourselves: track per-avatar error state and
+ * render the fallback instead of a broken `<img>` once it errors.
+ */
+const avatarPicture = (
+  key: string,
+  src: string,
+  alt: string,
+  fallback: string,
+  model: Model,
+  h: HtmlBuilder<AppMessage>,
+  className?: string,
+): Html =>
+  model.avatarImageErrors[key]
+    ? Avatar.fallback<AppMessage>({}, [fallback], h)
+    : h.img([
+        h.Src(src),
+        h.Alt(alt),
+        h.Class(cn(avatarImageClass, className)),
+        h.DataAttribute('slot', 'avatar-image'),
+        h.OnError(Message.AvatarImageErrored({ key })),
+      ])
+
+export const avatarView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
   h.div(
     [h.Class('flex flex-row flex-wrap items-center gap-6 md:gap-12')],
     [
-      Avatar<Message>(
+      Avatar<AppMessage>(
+        {},
+        [avatarPicture('top-shadcn', 'https://github.com/shadcn.png', '@shadcn', 'CN', model, h, 'grayscale')],
+        h,
+      ),
+      Avatar<AppMessage>(
         {},
         [
-          Avatar.image<Message>(
-            { src: 'https://github.com/shadcn.png', alt: '@shadcn', className: 'grayscale' },
-            h,
-          ),
-          Avatar.fallback<Message>({}, ['CN'], h),
+          avatarPicture('top-evilrabbit', 'https://github.com/evilrabbit.png', '@evilrabbit', 'ER', model, h),
+          Avatar.badge<AppMessage>({ className: 'bg-green-600 dark:bg-green-800' }, [], h),
         ],
         h,
       ),
-      Avatar<Message>(
-        {},
-        [
-          Avatar.image<Message>({ src: 'https://github.com/evilrabbit.png', alt: '@evilrabbit' }, h),
-          Avatar.fallback<Message>({}, ['ER'], h),
-          Avatar.badge<Message>({ className: 'bg-green-600 dark:bg-green-800' }, [], h),
-        ],
-        h,
-      ),
-      Avatar.group<Message>(
+      Avatar.group<AppMessage>(
         { className: 'grayscale' },
         [
-          Avatar<Message>(
+          Avatar<AppMessage>(
             {},
-            [
-              Avatar.image<Message>({ src: 'https://github.com/shadcn.png', alt: '@shadcn' }, h),
-              Avatar.fallback<Message>({}, ['CN'], h),
-            ],
+            [avatarPicture('group-shadcn', 'https://github.com/shadcn.png', '@shadcn', 'CN', model, h)],
             h,
           ),
-          Avatar<Message>(
+          Avatar<AppMessage>(
             {},
-            [
-              Avatar.image<Message>({ src: 'https://github.com/maxleiter.png', alt: '@maxleiter' }, h),
-              Avatar.fallback<Message>({}, ['LR'], h),
-            ],
+            [avatarPicture('group-maxleiter', 'https://github.com/maxleiter.png', '@maxleiter', 'LR', model, h)],
             h,
           ),
-          Avatar<Message>(
+          Avatar<AppMessage>(
             {},
-            [
-              Avatar.image<Message>({ src: 'https://github.com/evilrabbit.png', alt: '@evilrabbit' }, h),
-              Avatar.fallback<Message>({}, ['ER'], h),
-            ],
+            [avatarPicture('group-evilrabbit', 'https://github.com/evilrabbit.png', '@evilrabbit', 'ER', model, h)],
             h,
           ),
-          Avatar.groupCount<Message>({}, ['+3'], h),
+          Avatar.groupCount<AppMessage>({}, ['+3'], h),
         ],
         h,
       ),
     ],
   )
 
+const fields = { avatarImageErrors: S.Record(S.String, S.Boolean) }
+
+const stateSchema = S.Struct(fields)
+type State = typeof stateSchema.Type
+
 export const slice = defineSlice({
-  fields: {},
-  init: {},
-  messages: [],
-  handlers: () => ({}),
+  fields,
+  init: { avatarImageErrors: {} },
+  messages: [Message.AvatarImageErrored],
+  handlers: (model: State) => ({
+    AvatarImageErrored: ({ key }: typeof Message.AvatarImageErrored.Type): UpdateReturn => [
+      evo(model, { avatarImageErrors: (errors) => ({ ...errors, [key]: true }) }),
+      [],
+    ],
+  }),
+  samples: [Message.AvatarImageErrored({ key: 'top-shadcn' })],
 })


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Swap avatar fallback on image load error in demo view
- Adds an `AvatarImageErrored` message carrying a `key` to identify which avatar image failed, and a stateful avatar slice tracking per-key errors in `avatarImageErrors`
- Introduces the `avatarPicture` helper that renders an `<img>` with an `OnError` dispatcher, or falls back to `Avatar.fallback` when `model.avatarImageErrors[key]` is already `true`
- Wires `avatarSlice.handlers(model)` into the `M.tagsExhaustive` handler map in [assemble.ts](https://github.com/elianiva/foldcn/pull/10/files#diff-f46c9ac49dc27a30e1607a567eb2304a10251444a450328f17d3d27c50ea41f8) so avatar messages reach the slice
- Risk: `avatarView` in [avatar.ts](https://github.com/elianiva/foldcn/pull/10/files#diff-48692ea9424d4efcd5c7474bedb1ada82ea15a5aca39f953643f4b304527b7cf) no longer renders explicit `Avatar.fallback` children alongside `<img>`; fallback now depends entirely on error state being recorded by the slice

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 948c5c6.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->