### PR TITLE
chore: add Cloud Agent development environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,18 @@
+{
+  "name": "foldcn",
+  "install": "pnpm install --frozen-lockfile",
+  "start": "pnpm --filter @foldcn/web exec portless proxy start --port 1355 --https",
+  "terminals": [
+    {
+      "name": "dev",
+      "command": "pnpm dev",
+      "description": "foldcn showcase site (Foldkit SSG). Its predev hook re-resolves styles and regenerates the style shims, then Vite runs behind the portless proxy. Open the printed https://foldcn.localhost:1355 URL, or hit the raw Vite port shown as 'Local:' directly."
+    }
+  ],
+  "ports": [
+    {
+      "name": "portless-proxy",
+      "port": 1355
+    }
+  ]
+}

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,18 +1,17 @@
 {
   "name": "foldcn",
   "install": "pnpm install --frozen-lockfile",
-  "start": "pnpm --filter @foldcn/web exec portless proxy start --port 1355 --https",
   "terminals": [
     {
-      "name": "dev",
-      "command": "pnpm dev",
-      "description": "foldcn showcase site (Foldkit SSG). Its predev hook re-resolves styles and regenerates the style shims, then Vite runs behind the portless proxy. Open the printed https://foldcn.localhost:1355 URL, or hit the raw Vite port shown as 'Local:' directly."
+      "name": "web",
+      "command": "pnpm --filter @foldcn/web run predev && pnpm --filter @foldcn/web exec vite --port 5173 --strictPort --host 127.0.0.1",
+      "description": "foldcn showcase site on a fixed port (5173). Cursor Desktop auto-forwards this port to your machine at http://localhost:5173 (use the plug icon in the Agents window). The predev step re-resolves styles and regenerates the style shims first. Note: the repo's own `pnpm dev` wraps Vite in portless for local .localhost URLs; that layer is skipped here since it is useless off the VM."
     }
   ],
   "ports": [
     {
-      "name": "portless-proxy",
-      "port": 1355
+      "name": "web",
+      "port": 5173
     }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds `.cursor/environment.json` so Cursor Cloud Agents get a reproducible development environment for this repo.

- `install`: `pnpm install --frozen-lockfile` — installs the workspace against the committed lockfile (esbuild/workerd/msgpackr-extract/sharp build scripts are already pre-approved via `pnpm-workspace.yaml` `allowBuilds`).
- `terminals.web`: runs the showcase site's `predev` (re-resolve styles + regenerate style shims), then Vite on a **fixed port `5173`** (`--strictPort --host 127.0.0.1`).
- `ports`: exposes `5173`.

## Why

Two goals: make `pnpm`-based setup reproducible, and make the running site reliably reachable.

The repo's own `pnpm dev` wraps Vite in `portless`, which (a) needs a proxy started with `sudo` and (b) picks a random port each run — useless off the VM and awkward for port-forwarding. The cloud terminal instead runs Vite directly on a stable `5173`, so Cursor Desktop's automatic port-forwarding lands on a predictable `http://localhost:5173` every time (and it makes any manual tunnel target stable too). `portless` remains the local-dev path for humans; it's just skipped in the cloud env.

## Validation

- `pnpm install` — clean install, lockfile passes supply-chain policy.
- `pnpm test` — 11 tests pass across 2 files.
- `pnpm validate` — registry valid (5 files, 67 items).
- Fixed-port dev command serves HTTP 200 on `http://127.0.0.1:5173/`; homepage, component doc pages, and interactive previews (Button, Input, Card, Dialog, Checkbox) all render correctly.
- **Draft environment build `bld-20260830-d12d0b21` SUCCEEDED** — a fresh pod cloned the branch and ran `install` cleanly (exit 0, 6.4s), then snapshotted. (`install` is unchanged since that build.)

## Note (out of scope)

`pnpm typecheck` fails on a pre-existing type error in `packages/web/src/demo/views/toggle-group.ts` (present on a clean `master` checkout, unrelated to environment setup). Left untouched.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1acd3cee-7aa7-44af-badc-2f3949e6bf89?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1acd3cee-7aa7-44af-badc-2f3949e6bf89&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Cursor environment config for `@foldcn/web` dev server
> Adds [.cursor/environment.json](https://github.com/elianiva/foldcn/pull/23/files#diff-e1ffd6d714c0489804c88c05dc0d8d38fb427117251b73e8c4a3a4401c5cdb9e) to configure the project dev environment. It sets the install command to `pnpm install --frozen-lockfile`, defines a `web` terminal that runs the `predev` script for `@foldcn/web` followed by Vite on `127.0.0.1:5173` with strict port, and exposes port `5173`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f93e5a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->