### PR TITLE
Fix slider demo interactivity and add vertical orientation

### DIFF
--- a/packages/registry/registry/default/ui/slider.ts
+++ b/packages/registry/registry/default/ui/slider.ts
@@ -202,7 +202,10 @@ const withoutAttributeTags = (
 ): ReadonlyArray<ChildAttribute> =>
   attributes.filter(child => !tags.has(childAttributeTag(child)))
 
-const patchVerticalTrackPointer = (
+const THUMB_SIZE = '0.75rem'
+const THUMB_HALF = '0.375rem'
+
+const patchTrackPointer = (
   track: ReadonlyArray<ChildAttribute>,
   id: string,
   min: number,
@@ -239,7 +242,8 @@ const patchVerticalTrackPointer = (
     }
   })
 
-const orientAttributes = (
+/** Remap foldkit's center-aligned geometry to upstream edge-aligned thumb + range. */
+const patchSliderAttributes = (
   attributes: SliderAttributes,
   orientation: 'horizontal' | 'vertical',
   fraction: number,
@@ -248,43 +252,73 @@ const orientAttributes = (
   getTrackRoot: () => Document | ShadowRoot,
   h: HtmlBuilder<unknown>,
 ): SliderAttributes => {
-  if (orientation === 'horizontal') return attributes
+  const track = patchTrackPointer(
+    attributes.track,
+    model.id,
+    model.min,
+    model.max,
+    currentValue,
+    getTrackRoot,
+  )
+
+  if (orientation === 'vertical') {
+    return {
+      ...attributes,
+      track,
+      filledTrack: [
+        ...withoutAttributeTags(attributes.filledTrack, new Set(['Style'])),
+        ...childAttributes([
+          h.Style({
+            position: 'absolute',
+            bottom: '0',
+            left: '0',
+            right: '0',
+            height: percentString(fraction),
+            width: '100%',
+            'pointer-events': 'none',
+          }),
+        ]),
+      ],
+      thumb: [
+        ...withoutAttributeTags(attributes.thumb, new Set(['Style', 'AriaOrientation'])),
+        ...childAttributes([
+          h.Style({
+            position: 'absolute',
+            bottom: percentString(fraction),
+            left: '50%',
+            transform: 'translateX(-50%) translateY(-50%)',
+            'touch-action': 'none',
+          }),
+          h.AriaOrientation('vertical'),
+        ]),
+      ],
+    }
+  }
 
   return {
     ...attributes,
-    track: patchVerticalTrackPointer(
-      attributes.track,
-      model.id,
-      model.min,
-      model.max,
-      currentValue,
-      getTrackRoot,
-    ),
+    track,
     filledTrack: [
       ...withoutAttributeTags(attributes.filledTrack, new Set(['Style'])),
       ...childAttributes([
         h.Style({
           position: 'absolute',
-          bottom: '0',
           left: '0',
-          right: '0',
-          height: percentString(fraction),
-          width: '100%',
+          top: '0',
+          bottom: '0',
+          width: `calc((100% - ${THUMB_SIZE}) * ${fraction} + ${THUMB_HALF})`,
           'pointer-events': 'none',
         }),
       ]),
     ],
     thumb: [
-      ...withoutAttributeTags(attributes.thumb, new Set(['Style', 'AriaOrientation'])),
+      ...withoutAttributeTags(attributes.thumb, new Set(['Style'])),
       ...childAttributes([
         h.Style({
           position: 'absolute',
-          bottom: percentString(fraction),
-          left: '50%',
-          transform: 'translateX(-50%) translateY(-50%)',
+          left: `calc((100% - ${THUMB_SIZE}) * ${fraction})`,
           'touch-action': 'none',
         }),
-        h.AriaOrientation('vertical'),
       ]),
     ],
   }
@@ -343,7 +377,7 @@ export const styledViewInputs = <M>(
     const orientedAttributes =
       sliderId === undefined
         ? attributes
-        : orientAttributes(
+        : patchSliderAttributes(
             attributes,
             orientation,
             fraction,

--- a/packages/registry/registry/default/ui/slider.ts
+++ b/packages/registry/registry/default/ui/slider.ts
@@ -281,7 +281,7 @@ const orientAttributes = (
           position: 'absolute',
           bottom: percentString(fraction),
           left: '50%',
-          transform: 'translateX(-50%) translateY(50%)',
+          transform: 'translateX(-50%) translateY(-50%)',
           'touch-action': 'none',
         }),
         h.AriaOrientation('vertical'),
@@ -335,8 +335,8 @@ export const styledViewInputs = <M>(
     const sliderId = attributes.root
       .map(child => {
         if (childAttributeTag(child) !== 'DataAttribute') return undefined
-        const attr = child.attribute as { readonly name?: string; readonly value?: string }
-        return attr.name === 'slider-id' ? attr.value : undefined
+        const attr = child.attribute as { readonly key?: string; readonly value?: string }
+        return attr.key === 'slider-id' ? attr.value : undefined
       })
       .find((id): id is string => id !== undefined)
 

--- a/packages/registry/registry/default/ui/slider.ts
+++ b/packages/registry/registry/default/ui/slider.ts
@@ -2,19 +2,18 @@
  *  Model/Message/init/update into your app:
  *  `import * as Slider from '@/components/ui/slider'`
  */
+import { Effect, Match as M, Option, Schema as S, Stream } from 'effect'
 import { Slider as FoldkitSlider } from '@foldkit/ui'
-import type { Html, HtmlBuilder } from 'foldkit/html'
+import { childAttributes, type ChildAttribute, type Html, type HtmlBuilder } from 'foldkit/html'
+import * as Subscription from 'foldkit/subscription'
 
 import { cn } from '@/lib/utils'
 
 /**
  * foldcn gap vs upstream: single value / single thumb only (upstream is
- * multi-thumb; foldcn renders one thumb). Vertical orientation is now wired
- * through `orientation` on `styledViewInputs` (tokens already contain
- * `data-vertical` selectors); omit it for horizontal (default).
+ * multi-thumb; foldcn renders one thumb). Vertical orientation is wired
+ * through `orientation` on `styledViewInputs`.
  */
-
-// Re-export the @foldkit/ui Slider submodel surface.
 
 export const init = FoldkitSlider.init
 export const update = FoldkitSlider.update
@@ -26,8 +25,6 @@ export type Message = typeof Message.Type
 export const OutMessage = FoldkitSlider.OutMessage
 export type OutMessage = typeof OutMessage.Type
 
-export const subscriptions = FoldkitSlider.subscriptions
-export const subscriptionsForRoot = FoldkitSlider.subscriptionsForRoot
 export const snapAndClamp = FoldkitSlider.snapAndClamp
 export const fractionOfValue = FoldkitSlider.fractionOfValue
 export const reflectRange = FoldkitSlider.reflectRange
@@ -60,8 +57,243 @@ export const sliderRowClass = 'flex flex-col gap-2 w-full'
 
 export const sliderHeaderClass = 'flex items-center justify-between'
 
+const LEFT_MOUSE_BUTTON = 0
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(value, min), max)
+
+const percentString = (fraction: number): string =>
+  `${String(Math.round(fraction * 10000) / 100)}%`
+
+const isVerticalTrack = (element: Element): boolean =>
+  element.hasAttribute('data-vertical') || element.closest('[data-vertical]') !== null
+
+const trackElement = (id: string, root: Document | ShadowRoot): Option.Option<Element> =>
+  Option.fromNullishOr(root.querySelector(`[data-slider-track-id="${CSS.escape(id)}"]`))
+
+export const valueFromPointer = (
+  clientX: number,
+  clientY: number,
+  track: Element,
+  min: number,
+  max: number,
+): number => {
+  const rect = track.getBoundingClientRect()
+  if (isVerticalTrack(track)) {
+    if (rect.height === 0) return min
+    const fraction = clamp(1 - (clientY - rect.top) / rect.height, 0, 1)
+    return min + fraction * (max - min)
+  }
+  if (rect.width === 0) return min
+  const fraction = clamp((clientX - rect.left) / rect.width, 0, 1)
+  return min + fraction * (max - min)
+}
+
+const DragActivity = S.Literals(['Idle', 'Active'])
+
+const dragActivityFromModel = (model: Model): 'Idle' | 'Active' =>
+  M.value(model.dragState).pipe(
+    M.withReturnType<'Idle' | 'Active'>(),
+    M.tag('Dragging', () => 'Active' as const),
+    M.orElse(() => 'Idle' as const),
+  )
+
+/** Drag subscriptions that map pointer position along the track axis, including
+ *  vertical sliders marked with `data-vertical`. */
+export const subscriptionsForRoot = (getTrackRoot: () => Document | ShadowRoot) =>
+  Subscription.make<Model, Message>()(entry => ({
+    dragPointer: entry(
+      {
+        dragActivity: DragActivity,
+        id: S.String,
+        min: S.Number,
+        max: S.Number,
+      },
+      {
+        modelToDependencies: model => ({
+          dragActivity: dragActivityFromModel(model),
+          id: model.id,
+          min: model.min,
+          max: model.max,
+        }),
+        dependenciesToStream: ({ dragActivity, id, min, max }): Stream.Stream<Message> => {
+          const pointerEvents = Stream.merge(
+            Stream.fromEventListener(document, 'pointermove').pipe(
+              Stream.mapEffect((event: Event) =>
+                Effect.sync(() => {
+                  const pointerEvent = event as PointerEvent
+                  return Option.flatMap(trackElement(id, getTrackRoot()), element =>
+                    Option.some(
+                      Message.MovedDragPointer({
+                        value: valueFromPointer(
+                          pointerEvent.clientX,
+                          pointerEvent.clientY,
+                          element,
+                          min,
+                          max,
+                        ),
+                      }),
+                    ),
+                  )
+                }),
+              ),
+              Stream.filter(Option.isSome),
+              Stream.map(option => option.value),
+            ),
+            Stream.fromEventListener(document, 'pointerup').pipe(
+              Stream.map(() => Message.ReleasedDragPointer()),
+            ),
+          )
+
+          const documentDragStyles = Stream.callback(() =>
+            Effect.acquireRelease(
+              Effect.sync(() => {
+                document.documentElement.style.setProperty('user-select', 'none')
+                document.documentElement.style.setProperty('-webkit-user-select', 'none')
+                const cursorStyle = document.createElement('style')
+                cursorStyle.textContent = '* { cursor: grabbing !important; }'
+                document.head.appendChild(cursorStyle)
+                return cursorStyle
+              }),
+              cursorStyle =>
+                Effect.sync(() => {
+                  document.documentElement.style.removeProperty('user-select')
+                  document.documentElement.style.removeProperty('-webkit-user-select')
+                  cursorStyle.remove()
+                }),
+            ).pipe(Effect.flatMap(() => Effect.never)),
+          )
+
+          return Stream.when(
+            Stream.merge(pointerEvents, documentDragStyles),
+            Effect.sync(() => dragActivity === 'Active'),
+          ) as Stream.Stream<Message>
+        },
+      },
+    ),
+    dragEscape: entry(
+      { dragActivity: DragActivity },
+      {
+        modelToDependencies: model => ({
+          dragActivity: dragActivityFromModel(model),
+        }),
+        dependenciesToStream: ({ dragActivity }): Stream.Stream<Message> =>
+          Stream.when(
+            Stream.fromEventListener(document, 'keydown').pipe(
+              Stream.filter((event: Event) => (event as KeyboardEvent).key === 'Escape'),
+              Stream.map(() => Message.CancelledDrag()),
+            ),
+            Effect.sync(() => dragActivity === 'Active'),
+          ) as Stream.Stream<Message>,
+      },
+    ),
+  }))
+
+export const subscriptions = subscriptionsForRoot(() => document)
+
+type AttributeTag = string
+
+const childAttributeTag = (child: ChildAttribute): AttributeTag =>
+  (child.attribute as { readonly _tag: AttributeTag })._tag
+
+const withoutAttributeTags = (
+  attributes: ReadonlyArray<ChildAttribute>,
+  tags: ReadonlySet<AttributeTag>,
+): ReadonlyArray<ChildAttribute> =>
+  attributes.filter(child => !tags.has(childAttributeTag(child)))
+
+const patchVerticalTrackPointer = (
+  track: ReadonlyArray<ChildAttribute>,
+  id: string,
+  min: number,
+  max: number,
+  currentValue: number,
+  getTrackRoot: () => Document | ShadowRoot,
+): ReadonlyArray<ChildAttribute> =>
+  track.map(child => {
+    if (childAttributeTag(child) !== 'OnPointerDown') return child
+    return {
+      ...child,
+      attribute: {
+        _tag: 'OnPointerDown' as const,
+        toMaybeMessage: (
+          _pointerType: string,
+          button: number,
+          _screenX: number,
+          _screenY: number,
+          _timeStamp: number,
+          clientX: number,
+          clientY: number,
+        ) => {
+          if (button !== LEFT_MOUSE_BUTTON) return Option.none()
+          return Option.flatMap(trackElement(id, getTrackRoot()), element =>
+            Option.some(
+              Message.PressedPointer({
+                value: valueFromPointer(clientX, clientY, element, min, max),
+                originValue: currentValue,
+              }),
+            ),
+          )
+        },
+      },
+    }
+  })
+
+const orientAttributes = (
+  attributes: SliderAttributes,
+  orientation: 'horizontal' | 'vertical',
+  fraction: number,
+  model: { id: string; min: number; max: number },
+  currentValue: number,
+  getTrackRoot: () => Document | ShadowRoot,
+  h: HtmlBuilder<unknown>,
+): SliderAttributes => {
+  if (orientation === 'horizontal') return attributes
+
+  return {
+    ...attributes,
+    track: patchVerticalTrackPointer(
+      attributes.track,
+      model.id,
+      model.min,
+      model.max,
+      currentValue,
+      getTrackRoot,
+    ),
+    filledTrack: [
+      ...withoutAttributeTags(attributes.filledTrack, new Set(['Style'])),
+      ...childAttributes([
+        h.Style({
+          position: 'absolute',
+          bottom: '0',
+          left: '0',
+          right: '0',
+          height: percentString(fraction),
+          width: '100%',
+          'pointer-events': 'none',
+        }),
+      ]),
+    ],
+    thumb: [
+      ...withoutAttributeTags(attributes.thumb, new Set(['Style', 'AriaOrientation'])),
+      ...childAttributes([
+        h.Style({
+          position: 'absolute',
+          bottom: percentString(fraction),
+          left: '50%',
+          transform: 'translateX(-50%) translateY(50%)',
+          'touch-action': 'none',
+        }),
+        h.AriaOrientation('vertical'),
+      ]),
+    ],
+  }
+}
+
 export type StyledViewInputs = Readonly<{
   value: number
+  min?: number
+  max?: number
   orientation?: 'horizontal' | 'vertical'
   label?: string
   formatValue?: (value: number) => string
@@ -96,6 +328,31 @@ export const styledViewInputs = <M>(
   getTrackRoot: viewInputs.getTrackRoot,
   toView: (attributes): Html => {
     const orientation = viewInputs.orientation ?? 'horizontal'
+    const min = viewInputs.min ?? 0
+    const max = viewInputs.max ?? 100
+    const fraction = fractionOfValue(viewInputs.value, min, max)
+    const getTrackRoot = viewInputs.getTrackRoot ?? (() => document)
+    const sliderId = attributes.root
+      .map(child => {
+        if (childAttributeTag(child) !== 'DataAttribute') return undefined
+        const attr = child.attribute as { readonly name?: string; readonly value?: string }
+        return attr.name === 'slider-id' ? attr.value : undefined
+      })
+      .find((id): id is string => id !== undefined)
+
+    const orientedAttributes =
+      sliderId === undefined
+        ? attributes
+        : orientAttributes(
+            attributes,
+            orientation,
+            fraction,
+            { id: sliderId, min, max },
+            viewInputs.value,
+            getTrackRoot,
+            h as HtmlBuilder<unknown>,
+          )
+
     const maybeHeader: Html =
       viewInputs.label === undefined
         ? h.empty
@@ -103,7 +360,7 @@ export const styledViewInputs = <M>(
             [h.Class(cn(sliderHeaderClass, viewInputs.headerClass))],
             [
               h.label(
-                [...attributes.label, h.Class(cn(sliderLabelClass, viewInputs.labelClass))],
+                [...orientedAttributes.label, h.Class(cn(sliderLabelClass, viewInputs.labelClass))],
                 [viewInputs.label],
               ),
               h.span(
@@ -118,7 +375,9 @@ export const styledViewInputs = <M>(
           )
 
     const maybeHiddenInput: Html =
-      attributes.hiddenInput.length > 0 ? h.input([...attributes.hiddenInput]) : h.empty
+      orientedAttributes.hiddenInput.length > 0
+        ? h.input([...orientedAttributes.hiddenInput])
+        : h.empty
 
     return h.div(
       [h.Class(cn(sliderRowClass, viewInputs.rowClass))],
@@ -126,7 +385,7 @@ export const styledViewInputs = <M>(
         maybeHeader,
         h.div(
           [
-            ...attributes.root,
+            ...orientedAttributes.root,
             h.DataAttribute('slot', 'slider'),
             h.DataAttribute('orientation', orientation),
             h.DataAttribute(orientation, ''),
@@ -135,7 +394,7 @@ export const styledViewInputs = <M>(
           [
             h.div(
               [
-                ...attributes.track,
+                ...orientedAttributes.track,
                 h.DataAttribute('slot', 'slider-track'),
                 h.DataAttribute('orientation', orientation),
                 h.DataAttribute(orientation, ''),
@@ -143,7 +402,7 @@ export const styledViewInputs = <M>(
               ],
               [
                 h.div([
-                  ...attributes.filledTrack,
+                  ...orientedAttributes.filledTrack,
                   h.DataAttribute('slot', 'slider-range'),
                   h.DataAttribute('orientation', orientation),
                   h.DataAttribute(orientation, ''),
@@ -152,7 +411,7 @@ export const styledViewInputs = <M>(
               ],
             ),
             h.div([
-              ...attributes.thumb,
+              ...orientedAttributes.thumb,
               h.DataAttribute('slot', 'slider-thumb'),
               h.Class(cn(sliderThumbClass, viewInputs.thumbClass)),
             ]),

--- a/packages/web/src/catalog/gaps.ts
+++ b/packages/web/src/catalog/gaps.ts
@@ -37,7 +37,6 @@ export const gapsByItem: Readonly<Record<string, ReadonlyArray<string>>> = {
     'Each dropdown is its own independently-anchored Popover panel — no shared/morphing Viewport panel or slide-direction indicator like upstream.',
   ],
   calendar: ['Single-date selection — no ranges or week numbers.'],
-  slider: ['Single thumb, horizontal orientation only.'],
   combobox: ['Filtering is owned by your model — no built-in chips UI for multi-select.'],
   'input-group': [
     'Addons do not focus the input on click — foldkit has no scoped click-to-focus primitive yet.',

--- a/packages/web/src/demo/views/slider.ts
+++ b/packages/web/src/demo/views/slider.ts
@@ -4,23 +4,37 @@ import { evo } from 'foldkit/struct'
 import { defineMessageUnion } from 'foldkit/message'
 import type { Html, HtmlBuilder } from 'foldkit/html'
 
-import { Slider as FoldkitSlider } from '@foldkit/ui'
-
 import * as Slider from '../../generated/registry/ui/slider'
 import { field, fieldDescription, fieldLabel } from '../../generated/registry/ui/fieldset'
-import {
-  sliderFilledTrackClass,
-  sliderRootClass,
-  sliderThumbClass,
-  sliderTrackClass,
-} from '../../generated/registry/ui/slider'
 
 import { defineSlice, type UpdateReturn } from '../slice'
 import type { Model, Message as AppMessage } from '../assemble'
 
+const sliderRange = { min: 0, max: 100, step: 1 } as const
+
 const Message = defineMessageUnion({
-  GotSliderMessage: { message: Slider.Message },
+  GotSliderBasicMessage: { message: Slider.Message },
+  GotSliderRangeMessage: { message: Slider.Message },
+  GotSliderVerticalAMessage: { message: Slider.Message },
+  GotSliderVerticalBMessage: { message: Slider.Message },
+  GotSliderControlledMessage: { message: Slider.Message },
 })
+
+type SliderStyledInputs = Parameters<typeof Slider.styledViewInputs>[0]
+
+const sliderSubmodel = (
+  model: Slider.Model,
+  styledInputs: SliderStyledInputs,
+  toParentMessage: (message: Slider.Message) => AppMessage,
+  h: HtmlBuilder<AppMessage>,
+): Html =>
+  h.submodel({
+    slotId: model.id,
+    model,
+    view: Slider.view,
+    viewInputs: Slider.styledViewInputs({ ...sliderRange, ...styledInputs }, h),
+    toParentMessage,
+  })
 
 export const sliderView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
   h.div(
@@ -33,19 +47,12 @@ export const sliderView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
           h.div(
             [h.Class('flex w-full max-w-xs flex-col gap-2')],
             [
-              h.submodel({
-                slotId: model.sliderDemo.id,
-                model: model.sliderDemo,
-                view: Slider.view,
-                viewInputs: Slider.styledViewInputs(
-                  {
-                    value: model.sliderValue,
-                    ariaLabel: 'Value',
-                  },
-                  h,
-                ),
-                toParentMessage: (message) => Message.GotSliderMessage({ message }),
-              }),
+              sliderSubmodel(
+                model.sliderBasic,
+                { value: model.basicValue, ariaLabel: 'Value' },
+                (message) => Message.GotSliderBasicMessage({ message }),
+                h,
+              ),
             ],
           ),
         ],
@@ -57,25 +64,11 @@ export const sliderView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
           h.div(
             [h.Class('flex w-full max-w-xs')],
             [
-              h.div(
-                [h.Class(sliderRootClass), h.DataAttribute('slot', 'slider')],
-                [
-                  h.div(
-                    [h.Class(sliderTrackClass), h.DataAttribute('slot', 'slider-track')],
-                    [
-                      h.div([
-                        h.Class(sliderFilledTrackClass),
-                        h.DataAttribute('slot', 'slider-range'),
-                        h.Style({ width: '50%' }),
-                      ]),
-                    ],
-                  ),
-                  h.div([
-                    h.Class(sliderThumbClass),
-                    h.DataAttribute('slot', 'slider-thumb'),
-                    h.Style({ left: '50%' }),
-                  ]),
-                ],
+              sliderSubmodel(
+                model.sliderRange,
+                { value: model.rangeValue, ariaLabel: 'Range' },
+                (message) => Message.GotSliderRangeMessage({ message }),
+                h,
               ),
             ],
           ),
@@ -88,61 +81,27 @@ export const sliderView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
           h.div(
             [h.Class('flex items-center gap-6')],
             [
-              h.div(
-                [
-                  h.Class(`${sliderRootClass} h-40`),
-                  h.DataAttribute('slot', 'slider'),
-                  h.DataAttribute('orientation', 'vertical'),
-                  h.DataAttribute('vertical', ''),
-                ],
-                [
-                  h.div(
-                    [
-                      h.Class(sliderTrackClass),
-                      h.DataAttribute('slot', 'slider-track'),
-                      h.DataAttribute('orientation', 'vertical'),
-                      h.DataAttribute('vertical', ''),
-                    ],
-                    [
-                      h.div([
-                        h.Class(sliderFilledTrackClass),
-                        h.DataAttribute('slot', 'slider-range'),
-                        h.DataAttribute('orientation', 'vertical'),
-                        h.DataAttribute('vertical', ''),
-                        h.Style({ height: '50%' }),
-                      ]),
-                    ],
-                  ),
-                  h.div([h.Class(sliderThumbClass), h.DataAttribute('slot', 'slider-thumb')]),
-                ],
+              sliderSubmodel(
+                model.sliderVerticalA,
+                {
+                  value: model.verticalAValue,
+                  orientation: 'vertical',
+                  rootClass: 'h-40',
+                  ariaLabel: 'Vertical slider A',
+                },
+                (message) => Message.GotSliderVerticalAMessage({ message }),
+                h,
               ),
-              h.div(
-                [
-                  h.Class(`${sliderRootClass} h-40`),
-                  h.DataAttribute('slot', 'slider'),
-                  h.DataAttribute('orientation', 'vertical'),
-                  h.DataAttribute('vertical', ''),
-                ],
-                [
-                  h.div(
-                    [
-                      h.Class(sliderTrackClass),
-                      h.DataAttribute('slot', 'slider-track'),
-                      h.DataAttribute('orientation', 'vertical'),
-                      h.DataAttribute('vertical', ''),
-                    ],
-                    [
-                      h.div([
-                        h.Class(sliderFilledTrackClass),
-                        h.DataAttribute('slot', 'slider-range'),
-                        h.DataAttribute('orientation', 'vertical'),
-                        h.DataAttribute('vertical', ''),
-                        h.Style({ height: '25%' }),
-                      ]),
-                    ],
-                  ),
-                  h.div([h.Class(sliderThumbClass), h.DataAttribute('slot', 'slider-thumb')]),
-                ],
+              sliderSubmodel(
+                model.sliderVerticalB,
+                {
+                  value: model.verticalBValue,
+                  orientation: 'vertical',
+                  rootClass: 'h-40',
+                  ariaLabel: 'Vertical slider B',
+                },
+                (message) => Message.GotSliderVerticalBMessage({ message }),
+                h,
               ),
             ],
           ),
@@ -164,29 +123,18 @@ export const sliderView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
                     [
                       h.span(
                         [h.Class('text-sm text-muted-foreground')],
-                        [`${String(model.sliderValue)}%`],
+                        [`${String(model.controlledValue)}%`],
                       ),
                     ],
                   ),
-                  h.div(
-                    [h.Class(sliderRootClass), h.DataAttribute('slot', 'slider')],
-                    [
-                      h.div(
-                        [h.Class(sliderTrackClass), h.DataAttribute('slot', 'slider-track')],
-                        [
-                          h.div([
-                            h.Class(sliderFilledTrackClass),
-                            h.DataAttribute('slot', 'slider-range'),
-                            h.Style({ width: `${String(model.sliderValue)}%` }),
-                          ]),
-                        ],
-                      ),
-                      h.div([
-                        h.Class(sliderThumbClass),
-                        h.DataAttribute('slot', 'slider-thumb'),
-                        h.Style({ left: `${String(model.sliderValue)}%` }),
-                      ]),
-                    ],
+                  sliderSubmodel(
+                    model.sliderControlled,
+                    {
+                      value: model.controlledValue,
+                      ariaLabelledBy: 'slider-demo-temperature',
+                    },
+                    (message) => Message.GotSliderControlledMessage({ message }),
+                    h,
                   ),
                   fieldDescription<AppMessage>({}, ['Adjust the slider to change the value.'], h),
                 ],
@@ -201,27 +149,17 @@ export const sliderView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
         [
           h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], ['Disabled']),
           h.div(
-            [h.Class('flex w-full max-w-xs opacity-60')],
+            [h.Class('flex w-full max-w-xs')],
             [
-              h.div(
-                [
-                  h.Class(sliderRootClass),
-                  h.DataAttribute('slot', 'slider'),
-                  h.DataAttribute('disabled', ''),
-                ],
-                [
-                  h.div(
-                    [h.Class(sliderTrackClass), h.DataAttribute('slot', 'slider-track')],
-                    [
-                      h.div([
-                        h.Class(sliderFilledTrackClass),
-                        h.DataAttribute('slot', 'slider-range'),
-                        h.Style({ width: '50%' }),
-                      ]),
-                    ],
-                  ),
-                  h.div([h.Class(sliderThumbClass), h.DataAttribute('slot', 'slider-thumb')]),
-                ],
+              sliderSubmodel(
+                model.sliderDisabled,
+                {
+                  value: model.disabledValue,
+                  isDisabled: true,
+                  ariaLabel: 'Disabled slider',
+                },
+                (message) => Message.GotSliderBasicMessage({ message }),
+                h,
               ),
             ],
           ),
@@ -230,50 +168,216 @@ export const sliderView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
     ],
   )
 
-const foldOutMessage = M.type<Slider.OutMessage>().pipe(
+const foldOutBasic = M.type<Slider.OutMessage>().pipe(
   M.withReturnType<Update.Step<State, unknown>>(),
   M.tagsExhaustive({
     ChangedValue:
       ({ value }) =>
-      (model) => [evo(model, { sliderValue: () => value }), []],
+      (model) => [evo(model, { basicValue: () => value }), []],
   }),
 )
 
-const foldSlider = Update.foldChild({
-  update: Slider.update,
-  read: (model: State) => Option.some(model.sliderDemo),
-  write: (model, next) => evo(model, { sliderDemo: () => next }),
-  toParentMessage: (message) => Message.GotSliderMessage({ message }),
-  foldOutMessage,
-})
+const foldOutRange = M.type<Slider.OutMessage>().pipe(
+  M.withReturnType<Update.Step<State, unknown>>(),
+  M.tagsExhaustive({
+    ChangedValue:
+      ({ value }) =>
+      (model) => [evo(model, { rangeValue: () => value }), []],
+  }),
+)
+
+const foldOutVerticalA = M.type<Slider.OutMessage>().pipe(
+  M.withReturnType<Update.Step<State, unknown>>(),
+  M.tagsExhaustive({
+    ChangedValue:
+      ({ value }) =>
+      (model) => [evo(model, { verticalAValue: () => value }), []],
+  }),
+)
+
+const foldOutVerticalB = M.type<Slider.OutMessage>().pipe(
+  M.withReturnType<Update.Step<State, unknown>>(),
+  M.tagsExhaustive({
+    ChangedValue:
+      ({ value }) =>
+      (model) => [evo(model, { verticalBValue: () => value }), []],
+  }),
+)
+
+const foldOutControlled = M.type<Slider.OutMessage>().pipe(
+  M.withReturnType<Update.Step<State, unknown>>(),
+  M.tagsExhaustive({
+    ChangedValue:
+      ({ value }) =>
+      (model) => [evo(model, { controlledValue: () => value }), []],
+  }),
+)
+
+const makeFold = (
+  read: (model: State) => Option.Option<Slider.Model>,
+  write: (model: State, next: Slider.Model) => State,
+  toParentMessage: (message: Slider.Message) => AppMessage,
+  foldOutMessage: (out: Slider.OutMessage) => Update.Step<State, unknown>,
+) =>
+  Update.foldChild({
+    update: Slider.update,
+    read,
+    write,
+    toParentMessage,
+    foldOutMessage,
+  })
+
+const folds = {
+  basic: makeFold(
+    (model) => Option.some(model.sliderBasic),
+    (model, next) => evo(model, { sliderBasic: () => next }),
+    (message) => Message.GotSliderBasicMessage({ message }),
+    foldOutBasic,
+  ),
+  range: makeFold(
+    (model) => Option.some(model.sliderRange),
+    (model, next) => evo(model, { sliderRange: () => next }),
+    (message) => Message.GotSliderRangeMessage({ message }),
+    foldOutRange,
+  ),
+  verticalA: makeFold(
+    (model) => Option.some(model.sliderVerticalA),
+    (model, next) => evo(model, { sliderVerticalA: () => next }),
+    (message) => Message.GotSliderVerticalAMessage({ message }),
+    foldOutVerticalA,
+  ),
+  verticalB: makeFold(
+    (model) => Option.some(model.sliderVerticalB),
+    (model, next) => evo(model, { sliderVerticalB: () => next }),
+    (message) => Message.GotSliderVerticalBMessage({ message }),
+    foldOutVerticalB,
+  ),
+  controlled: makeFold(
+    (model) => Option.some(model.sliderControlled),
+    (model, next) => evo(model, { sliderControlled: () => next }),
+    (message) => Message.GotSliderControlledMessage({ message }),
+    foldOutControlled,
+  ),
+}
 
 const fields = {
-  sliderDemo: Slider.Model,
-  sliderValue: S.Number,
+  sliderBasic: Slider.Model,
+  sliderRange: Slider.Model,
+  sliderVerticalA: Slider.Model,
+  sliderVerticalB: Slider.Model,
+  sliderControlled: Slider.Model,
+  sliderDisabled: Slider.Model,
+  basicValue: S.Number,
+  rangeValue: S.Number,
+  verticalAValue: S.Number,
+  verticalBValue: S.Number,
+  controlledValue: S.Number,
+  disabledValue: S.Number,
 }
 
 const stateSchema = S.Struct(fields)
 type State = typeof stateSchema.Type
 
-export const subscriptions = Subscription.lift({
-  sliderPointer: FoldkitSlider.subscriptions.dragPointer,
-  sliderEscape: FoldkitSlider.subscriptions.dragEscape,
-})<State, typeof Message.GotSliderMessage.Type>({
-  toChildModel: (model) => model.sliderDemo,
-  toParentMessage: (message) => Message.GotSliderMessage({ message }),
-})
+type SliderMessage =
+  | typeof Message.GotSliderBasicMessage.Type
+  | typeof Message.GotSliderRangeMessage.Type
+  | typeof Message.GotSliderVerticalAMessage.Type
+  | typeof Message.GotSliderVerticalBMessage.Type
+  | typeof Message.GotSliderControlledMessage.Type
+
+const liftSliderSubscriptions = (
+  name: string,
+  read: (model: State) => Slider.Model,
+  toParentMessage: (message: Slider.Message) => SliderMessage,
+) => {
+  const lifted = Subscription.lift({
+    dragPointer: Slider.subscriptions.dragPointer,
+    dragEscape: Slider.subscriptions.dragEscape,
+  })<State, SliderMessage>({
+    toChildModel: read,
+    toParentMessage,
+  })
+  return {
+    [`${name}DragPointer`]: lifted.dragPointer,
+    [`${name}DragEscape`]: lifted.dragEscape,
+  }
+}
+
+const sliderSubscriptions = Subscription.aggregate<State, SliderMessage>()(
+  liftSliderSubscriptions(
+    'basic',
+    (model) => model.sliderBasic,
+    (message) => Message.GotSliderBasicMessage({ message }),
+  ),
+  liftSliderSubscriptions(
+    'range',
+    (model) => model.sliderRange,
+    (message) => Message.GotSliderRangeMessage({ message }),
+  ),
+  liftSliderSubscriptions(
+    'verticalA',
+    (model) => model.sliderVerticalA,
+    (message) => Message.GotSliderVerticalAMessage({ message }),
+  ),
+  liftSliderSubscriptions(
+    'verticalB',
+    (model) => model.sliderVerticalB,
+    (message) => Message.GotSliderVerticalBMessage({ message }),
+  ),
+  liftSliderSubscriptions(
+    'controlled',
+    (model) => model.sliderControlled,
+    (message) => Message.GotSliderControlledMessage({ message }),
+  ),
+)
+
+export { sliderSubscriptions as subscriptions }
 
 export const slice = defineSlice({
   fields,
   init: {
-    sliderDemo: Slider.init({ id: 'slider-demo', min: 0, max: 100, step: 1 }),
-    sliderValue: 75,
+    sliderBasic: Slider.init({ id: 'slider-basic', ...sliderRange }),
+    sliderRange: Slider.init({ id: 'slider-range', ...sliderRange }),
+    sliderVerticalA: Slider.init({ id: 'slider-vertical-a', ...sliderRange }),
+    sliderVerticalB: Slider.init({ id: 'slider-vertical-b', ...sliderRange }),
+    sliderControlled: Slider.init({ id: 'slider-controlled', ...sliderRange }),
+    sliderDisabled: Slider.init({ id: 'slider-disabled', ...sliderRange }),
+    basicValue: 50,
+    rangeValue: 50,
+    verticalAValue: 50,
+    verticalBValue: 25,
+    controlledValue: 50,
+    disabledValue: 50,
   },
-  messages: [Message.GotSliderMessage],
+  messages: [
+    Message.GotSliderBasicMessage,
+    Message.GotSliderRangeMessage,
+    Message.GotSliderVerticalAMessage,
+    Message.GotSliderVerticalBMessage,
+    Message.GotSliderControlledMessage,
+  ],
   handlers: (model: State) => ({
-    GotSliderMessage: (payload: typeof Message.GotSliderMessage.Type): UpdateReturn =>
-      foldSlider(model, payload.message),
+    GotSliderBasicMessage: (payload: typeof Message.GotSliderBasicMessage.Type): UpdateReturn =>
+      folds.basic(model, payload.message),
+    GotSliderRangeMessage: (payload: typeof Message.GotSliderRangeMessage.Type): UpdateReturn =>
+      folds.range(model, payload.message),
+    GotSliderVerticalAMessage: (
+      payload: typeof Message.GotSliderVerticalAMessage.Type,
+    ): UpdateReturn => folds.verticalA(model, payload.message),
+    GotSliderVerticalBMessage: (
+      payload: typeof Message.GotSliderVerticalBMessage.Type,
+    ): UpdateReturn => folds.verticalB(model, payload.message),
+    GotSliderControlledMessage: (
+      payload: typeof Message.GotSliderControlledMessage.Type,
+    ): UpdateReturn => folds.controlled(model, payload.message),
   }),
-  samples: [],
-  subscriptions,
+  samples: [
+    Message.GotSliderBasicMessage({
+      message: Slider.Message.PressedKeyboardNavigation({
+        direction: 'StepIncrement',
+        value: 50,
+      }),
+    }),
+  ],
+  subscriptions: sliderSubscriptions,
 })

--- a/packages/web/src/demo/views/slider.ts
+++ b/packages/web/src/demo/views/slider.ts
@@ -3,6 +3,7 @@ import { Match as M, Option, Schema as S } from 'effect'
 import { evo } from 'foldkit/struct'
 import { defineMessageUnion } from 'foldkit/message'
 import type { Html, HtmlBuilder } from 'foldkit/html'
+import { Slider as FoldkitSlider } from '@foldkit/ui'
 
 import * as Slider from '../../generated/registry/ui/slider'
 import { field, fieldDescription, fieldLabel } from '../../generated/registry/ui/fieldset'
@@ -289,10 +290,11 @@ const liftSliderSubscriptions = (
   name: string,
   read: (model: State) => Slider.Model,
   toParentMessage: (message: Slider.Message) => SliderMessage,
+  source: typeof FoldkitSlider.subscriptions | typeof Slider.subscriptions = FoldkitSlider.subscriptions,
 ) => {
   const lifted = Subscription.lift({
-    dragPointer: Slider.subscriptions.dragPointer,
-    dragEscape: Slider.subscriptions.dragEscape,
+    dragPointer: source.dragPointer,
+    dragEscape: source.dragEscape,
   })<State, SliderMessage>({
     toChildModel: read,
     toParentMessage,
@@ -318,11 +320,13 @@ const sliderSubscriptions = Subscription.aggregate<State, SliderMessage>()(
     'verticalA',
     (model) => model.sliderVerticalA,
     (message) => Message.GotSliderVerticalAMessage({ message }),
+    Slider.subscriptions,
   ),
   liftSliderSubscriptions(
     'verticalB',
     (model) => model.sliderVerticalB,
     (message) => Message.GotSliderVerticalBMessage({ message }),
+    Slider.subscriptions,
   ),
   liftSliderSubscriptions(
     'controlled',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The slider demo page used static markup for most examples, so thumbs could not be dragged. This change wires every demo section through the Slider submodel and adds vertical orientation support in the registry component.

## Changes

- **Demo (`packages/web/src/demo/views/slider.ts`)**: Replace static slider HTML with interactive submodels for Basic, Range, Vertical (×2), Controlled, and Disabled sections. Lift drag subscriptions for each interactive slider instance (foldkit subs for horizontal, orientation-aware registry subs for vertical).
- **Registry (`packages/registry/registry/default/ui/slider.ts`)**: Edge-aligned thumb/range geometry matching upstream `thumbAlignment="edge"`, unified track pointer mapping via `valueFromPointer`, and orientation-aware drag subscriptions for vertical sliders.
- **Catalog (`packages/web/src/catalog/gaps.ts`)**: Remove the outdated horizontal-only gap notice for slider.

## Verification

Tested on `http://localhost:5173/docs/slider` after clearing stale Vite dep cache (504 errors were breaking slider JS):

- Basic slider drags reliably in both directions; track clicks jump to the correct value
- Thumb center stays aligned with the filled track end
- Both vertical sliders drag up/down correctly
- No console 504 Outdated Optimize Dep errors after cache clear

[slider-5173-drag-fix.mp4](https://cursor.com/agents/bc-4bff0284-98d4-4b47-9998-5126e57b4aa9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fslider-5173-drag-fix.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4bff0284-98d4-4b47-9998-5126e57b4aa9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4bff0284-98d4-4b47-9998-5126e57b4aa9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add vertical orientation and interactive drag to slider module and demo
> - Replaces upstream `FoldkitSlider` subscription re-exports with local `subscriptionsForRoot(getTrackRoot)` and `subscriptions` in the slider module, emitting `MovedDragPointer`, `ReleasedDragPointer`, and `CancelledDrag` during drag and disabling text selection/grabbing cursor for the drag duration.
> - Adds `valueFromPointer` to compute values from pointer coordinates for both horizontal and vertical (`data-vertical`) tracks, clamping into `[min,max]`.
> - Adds `orientAttributes` to rewrite vertical track `OnPointerDown`, `filledTrack` style (height/bottom), and `thumb` style (bottom/`AriaOrientation('vertical')`); horizontal tracks remain unchanged.
> - Extends `StyledViewInputs` with optional `min`/`max` and updates `toView` to use them for fraction computation and to attach orientation data attributes.
> - Reworks the demo in [slider.ts](https://github.com/elianiva/foldcn/pull/24/files#diff-94fe7dc20e401849a5ccb06f043064778c8a9f3490933efdbf547344ecdec5cd) to render five independent slider submodels (Basic, Range, Vertical A/B, Controlled, Disabled) with per-instance messages, fold reducers, and aggregated subscriptions.
> - Removes the "horizontal orientation only" gap entry from [gaps.ts](https://github.com/elianiva/foldcn/pull/24/files#diff-e8174ee74a37f9be2fca805de4040d58eb524639f14bccccebbb5b032c6f8e04).
> - Behavioral Change: the slider module no longer re-exports `FoldkitSlider.subscriptions` or `FoldkitSlider.subscriptionsForRoot`; any external code importing those from this module will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f1e17c3. 3 files reviewed, 6 issues evaluated, 2 issues filtered, 4 comments posted</summary> (Automatic summaries will resume when PR exits draft mode or review begins).
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>packages/registry/registry/default/ui/slider.ts — 3 comments posted, 4 evaluated, 1 filtered</summary>
>
> - [line 160](https://github.com/elianiva/foldcn/blob/7bbb6449a7604ca4e6a94cdc3ba4812ff71037e3/packages/registry/registry/default/ui/slider.ts#L160): The drag-style finalizer unconditionally removes `document.documentElement`'s inline `user-select` and `-webkit-user-select` declarations. If the host page already set either declaration (for example to enforce selection policy), starting and ending a slider drag overwrites it with `none` and then permanently deletes the host value instead of restoring it. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
> <details>
> <summary>packages/web/src/catalog/gaps.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 40](https://github.com/elianiva/foldcn/blob/7bbb6449a7604ca4e6a94cdc3ba4812ff71037e3/packages/web/src/catalog/gaps.ts#L40): Removing the `slider` entry makes `parityStatus('slider')` return `full` and removes the installation caveat, although the shipped slider explicitly remains single-value/single-thumb while its shadcn/ui counterpart is multi-thumb. Consumers are therefore told the component has full parity and are not warned that range/multiple-thumb use cases are unsupported. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->