### PR TITLE
Use plain Vite for dev; move portless to dev:local

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -5,7 +5,7 @@
     {
       "name": "web",
       "command": "pnpm --filter @foldcn/web run predev && pnpm --filter @foldcn/web exec vite --port 5173 --strictPort --host 127.0.0.1",
-      "description": "foldcn showcase site on a fixed port (5173). Cursor Desktop auto-forwards this port to your machine at http://localhost:5173 (use the plug icon in the Agents window). The predev step re-resolves styles and regenerates the style shims first. Note: the repo's own `pnpm dev` wraps Vite in portless for local .localhost URLs; that layer is skipped here since it is useless off the VM."
+      "description": "foldcn showcase site on a fixed port (5173). Cursor Desktop auto-forwards this port to your machine at http://localhost:5173 (use the plug icon in the Agents window). The predev step re-resolves styles and regenerates the style shims first. Use `pnpm dev:local` in the repo for portless .localhost URLs; this terminal runs plain Vite instead."
     }
   ],
   "ports": [

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,7 +6,9 @@
   "type": "module",
   "scripts": {
     "predev": "node ../registry/scripts/resolve-styles.mjs && node scripts/generate-style-shims.mjs",
-    "dev": "portless run --name foldcn vite",
+    "dev": "vite",
+    "predev:local": "node ../registry/scripts/resolve-styles.mjs && node scripts/generate-style-shims.mjs",
+    "dev:local": "portless run --name foldcn vite",
     "prebuild": "node ../registry/scripts/resolve-styles.mjs && node scripts/generate-style-shims.mjs",
     "pretypecheck": "node ../registry/scripts/resolve-styles.mjs && node scripts/generate-style-shims.mjs",
     "pretest": "node ../registry/scripts/resolve-styles.mjs && node scripts/generate-style-shims.mjs",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `pnpm dev` now runs plain `vite` (default Vite dev server on port 5173).
- Portless `.localhost` URLs are available via `pnpm dev:local` in `@foldcn/web`.
- Cloud environment terminal description updated to reflect the new split.

## Motivation

Portless is useful for local development with stable `.localhost` hostnames, but it adds an extra layer that is unnecessary in most environments (including cloud agents), where plain Vite on a fixed port is simpler.

## Testing

- Ran `pnpm run predev && pnpm run dev` in `packages/web`; Vite started successfully on `http://localhost:5173/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-312a1a24-140c-4b6d-84d5-0ee9d6d23d33?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-312a1a24-140c-4b6d-84d5-0ee9d6d23d33&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run plain Vite for `dev` and move portless to `dev:local`
> The `dev` script in [package.json](https://github.com/elianiva/foldcn/pull/25/files#diff-e35631c960979816b4b2bda7950788e968930fcaf2cf39b482ff23117cd13888) now runs `vite` directly instead of wrapping it in portless. A new `dev:local` script runs the same portless setup as before, with a `predev:local` lifecycle hook for style resolution and shim generation. The showcase site notes in [environment.json](https://github.com/elianiva/foldcn/pull/25/files#diff-e1ffd6d714c0489804c88c05dc0d8d38fb427117251b73e8c4a3a4401c5cdb9e) are updated to match.
>
> Risk: anyone relying on `pnpm dev` for `.localhost` portless URLs must switch to `pnpm dev:local`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd027c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->