### PR TITLE
fix: align button icons with shadcn

### DIFF
--- a/packages/registry/registry/default/lib/icons.ts
+++ b/packages/registry/registry/default/lib/icons.ts
@@ -64,8 +64,15 @@ const nodeToAttributes = <M>(
 
 const defaultIconClass = 'size-4 shrink-0'
 
-export const icon = <M>(h: HtmlBuilder<M>, node: IconNode, className = defaultIconClass): Html =>
+export type IconPosition = 'inline-start' | 'inline-end'
+
+export const icon = <M>(
+  h: HtmlBuilder<M>,
+  node: IconNode,
+  className = defaultIconClass,
+  position?: IconPosition,
+): Html =>
   h.svg(
-    svgAttributes(className, h),
+    [...svgAttributes(className, h), ...(position ? [h.DataAttribute('icon', position)] : [])],
     node.map(([tag, attrs]) => svgElement(tag, h)(nodeToAttributes(attrs, h))),
   )

--- a/packages/registry/registry/default/ui/button.ts
+++ b/packages/registry/registry/default/ui/button.ts
@@ -66,8 +66,10 @@ export type ButtonConfig<M> = Readonly<{
   attributes?: ReadonlyArray<Attribute<M>>
 }>
 
+export type ButtonLabel = Html | string | ReadonlyArray<Html | string>
+
 /** Styled button built on the @foldkit/ui Button helper. */
-export const button = <M>(config: ButtonConfig<M>, label: Html | string, h: HtmlBuilder<M>): Html =>
+export const button = <M>(config: ButtonConfig<M>, label: ButtonLabel, h: HtmlBuilder<M>): Html =>
   FoldkitButton.view<M>(
     {
       onClick: config.onClick,
@@ -89,7 +91,7 @@ export const button = <M>(config: ButtonConfig<M>, label: Html | string, h: Html
             h.DataAttribute('slot', 'button'),
             ...(config.attributes ?? []),
           ],
-          [label],
+          Array.isArray(label) ? label : [label],
         ),
     },
     h,

--- a/packages/web/src/demo/views/button.ts
+++ b/packages/web/src/demo/views/button.ts
@@ -70,32 +70,32 @@ export const buttonView = (_model: Model, h: HtmlBuilder<Message>): Html =>
             [
               button<Message>(
                 { size: 'xs' },
-                h.span([], ['Default ', icon(h, ArrowRight, 'size-3')]),
+                ['Default ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
               button<Message>(
                 { size: 'xs', variant: 'secondary' },
-                h.span([], ['Secondary ', icon(h, ArrowRight, 'size-3')]),
+                ['Secondary ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
               button<Message>(
                 { size: 'xs', variant: 'outline' },
-                h.span([], ['Outline ', icon(h, ArrowRight, 'size-3')]),
+                ['Outline ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
               button<Message>(
                 { size: 'xs', variant: 'ghost' },
-                h.span([], ['Ghost ', icon(h, ArrowRight, 'size-3')]),
+                ['Ghost ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
               button<Message>(
                 { size: 'xs', variant: 'destructive' },
-                h.span([], ['Destructive ', icon(h, ArrowRight, 'size-3')]),
+                ['Destructive ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
               button<Message>(
                 { size: 'xs', variant: 'link' },
-                h.span([], ['Link ', icon(h, ArrowRight, 'size-3')]),
+                ['Link ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
             ],
@@ -105,32 +105,32 @@ export const buttonView = (_model: Model, h: HtmlBuilder<Message>): Html =>
             [
               button<Message>(
                 { size: 'sm' },
-                h.span([], ['Default ', icon(h, ArrowRight, 'size-3')]),
+                ['Default ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
               button<Message>(
                 { size: 'sm', variant: 'secondary' },
-                h.span([], ['Secondary ', icon(h, ArrowRight, 'size-3')]),
+                ['Secondary ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
               button<Message>(
                 { size: 'sm', variant: 'outline' },
-                h.span([], ['Outline ', icon(h, ArrowRight, 'size-3')]),
+                ['Outline ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
               button<Message>(
                 { size: 'sm', variant: 'ghost' },
-                h.span([], ['Ghost ', icon(h, ArrowRight, 'size-3')]),
+                ['Ghost ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
               button<Message>(
                 { size: 'sm', variant: 'destructive' },
-                h.span([], ['Destructive ', icon(h, ArrowRight, 'size-3')]),
+                ['Destructive ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
               button<Message>(
                 { size: 'sm', variant: 'link' },
-                h.span([], ['Link ', icon(h, ArrowRight, 'size-3')]),
+                ['Link ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
             ],
@@ -138,30 +138,30 @@ export const buttonView = (_model: Model, h: HtmlBuilder<Message>): Html =>
           h.div(
             [h.Class('flex flex-wrap items-center gap-2')],
             [
-              button<Message>({}, h.span([], ['Default ', icon(h, ArrowRight, 'size-3')]), h),
+              button<Message>({}, ['Default ', icon(h, ArrowRight, 'size-3', 'inline-end')], h),
               button<Message>(
                 { variant: 'secondary' },
-                h.span([], ['Secondary ', icon(h, ArrowRight, 'size-3')]),
+                ['Secondary ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
               button<Message>(
                 { variant: 'outline' },
-                h.span([], ['Outline ', icon(h, ArrowRight, 'size-3')]),
+                ['Outline ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
               button<Message>(
                 { variant: 'ghost' },
-                h.span([], ['Ghost ', icon(h, ArrowRight, 'size-3')]),
+                ['Ghost ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
               button<Message>(
                 { variant: 'destructive' },
-                h.span([], ['Destructive ', icon(h, ArrowRight, 'size-3')]),
+                ['Destructive ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
               button<Message>(
                 { variant: 'link' },
-                h.span([], ['Link ', icon(h, ArrowRight, 'size-3')]),
+                ['Link ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
             ],
@@ -171,32 +171,32 @@ export const buttonView = (_model: Model, h: HtmlBuilder<Message>): Html =>
             [
               button<Message>(
                 { size: 'lg' },
-                h.span([], ['Default ', icon(h, ArrowRight, 'size-3')]),
+                ['Default ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
               button<Message>(
                 { size: 'lg', variant: 'secondary' },
-                h.span([], ['Secondary ', icon(h, ArrowRight, 'size-3')]),
+                ['Secondary ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
               button<Message>(
                 { size: 'lg', variant: 'outline' },
-                h.span([], ['Outline ', icon(h, ArrowRight, 'size-3')]),
+                ['Outline ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
               button<Message>(
                 { size: 'lg', variant: 'ghost' },
-                h.span([], ['Ghost ', icon(h, ArrowRight, 'size-3')]),
+                ['Ghost ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
               button<Message>(
                 { size: 'lg', variant: 'destructive' },
-                h.span([], ['Destructive ', icon(h, ArrowRight, 'size-3')]),
+                ['Destructive ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
               button<Message>(
                 { size: 'lg', variant: 'link' },
-                h.span([], ['Link ', icon(h, ArrowRight, 'size-3')]),
+                ['Link ', icon(h, ArrowRight, 'size-3', 'inline-end')],
                 h,
               ),
             ],
@@ -212,32 +212,32 @@ export const buttonView = (_model: Model, h: HtmlBuilder<Message>): Html =>
             [
               button<Message>(
                 { size: 'xs' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Default']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Default'],
                 h,
               ),
               button<Message>(
                 { size: 'xs', variant: 'secondary' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Secondary']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Secondary'],
                 h,
               ),
               button<Message>(
                 { size: 'xs', variant: 'outline' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Outline']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Outline'],
                 h,
               ),
               button<Message>(
                 { size: 'xs', variant: 'ghost' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Ghost']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Ghost'],
                 h,
               ),
               button<Message>(
                 { size: 'xs', variant: 'destructive' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Destructive']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Destructive'],
                 h,
               ),
               button<Message>(
                 { size: 'xs', variant: 'link' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Link']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Link'],
                 h,
               ),
             ],
@@ -247,32 +247,32 @@ export const buttonView = (_model: Model, h: HtmlBuilder<Message>): Html =>
             [
               button<Message>(
                 { size: 'sm' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Default']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Default'],
                 h,
               ),
               button<Message>(
                 { size: 'sm', variant: 'secondary' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Secondary']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Secondary'],
                 h,
               ),
               button<Message>(
                 { size: 'sm', variant: 'outline' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Outline']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Outline'],
                 h,
               ),
               button<Message>(
                 { size: 'sm', variant: 'ghost' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Ghost']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Ghost'],
                 h,
               ),
               button<Message>(
                 { size: 'sm', variant: 'destructive' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Destructive']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Destructive'],
                 h,
               ),
               button<Message>(
                 { size: 'sm', variant: 'link' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Link']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Link'],
                 h,
               ),
             ],
@@ -280,30 +280,34 @@ export const buttonView = (_model: Model, h: HtmlBuilder<Message>): Html =>
           h.div(
             [h.Class('flex flex-wrap items-center gap-2')],
             [
-              button<Message>({}, h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Default']), h),
+              button<Message>(
+                {},
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Default'],
+                h,
+              ),
               button<Message>(
                 { variant: 'secondary' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Secondary']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Secondary'],
                 h,
               ),
               button<Message>(
                 { variant: 'outline' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Outline']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Outline'],
                 h,
               ),
               button<Message>(
                 { variant: 'ghost' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Ghost']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Ghost'],
                 h,
               ),
               button<Message>(
                 { variant: 'destructive' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Destructive']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Destructive'],
                 h,
               ),
               button<Message>(
                 { variant: 'link' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Link']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Link'],
                 h,
               ),
             ],
@@ -313,32 +317,32 @@ export const buttonView = (_model: Model, h: HtmlBuilder<Message>): Html =>
             [
               button<Message>(
                 { size: 'lg' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Default']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Default'],
                 h,
               ),
               button<Message>(
                 { size: 'lg', variant: 'secondary' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Secondary']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Secondary'],
                 h,
               ),
               button<Message>(
                 { size: 'lg', variant: 'outline' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Outline']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Outline'],
                 h,
               ),
               button<Message>(
                 { size: 'lg', variant: 'ghost' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Ghost']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Ghost'],
                 h,
               ),
               button<Message>(
                 { size: 'lg', variant: 'destructive' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Destructive']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Destructive'],
                 h,
               ),
               button<Message>(
                 { size: 'lg', variant: 'link' },
-                h.span([], [icon(h, ArrowLeftCircle, 'size-3'), ' Link']),
+                [icon(h, ArrowLeftCircle, 'size-3', 'inline-start'), ' Link'],
                 h,
               ),
             ],
@@ -502,7 +506,7 @@ export const buttonView = (_model: Model, h: HtmlBuilder<Message>): Html =>
                 [h.Class('flex items-center gap-2')],
                 [
                   button<Message>({ variant: 'outline' }, 'Cancel', h),
-                  button<Message>({}, h.span([], ['Submit ', icon(h, ArrowRight, 'size-3')]), h),
+                  button<Message>({}, ['Submit ', icon(h, ArrowRight, 'size-3', 'inline-end')], h),
                 ],
               ),
               h.div(


### PR DESCRIPTION
## What
- allow buttons to render icon and text as direct children
- add `data-icon="inline-start|inline-end"` support to the Foldcn icon helper
- update the button demo to use shadcn's icon spacing contract

## Why
Button icons were wrapped in a span, so the flex layout and shadcn icon-spacing selectors did not apply correctly.

## Relationship
Blocked by #29, which fixes the repository typecheck baseline. After #29 merges, this PR should pass CI without changes.

## Verification
- formatting check
- `pnpm lint`
- `pnpm typecheck` (passes on the branch including #29)
- `pnpm test`
- `pnpm validate`
- production web build

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align `button` icons with shadcn using `IconPosition` and array labels
> - Introduces `IconPosition` type (`inline-start` | `inline-end`) in [icons.ts](https://github.com/elianiva/foldcn/pull/30/files#diff-c81f7877ccffcad28207f9cd6c956da73cf548763b04f91ab77ca22ff1bdbed9). The `icon` helper sets a `data-icon` attribute on the `<svg>` element when a position is provided.
> - Updates `ButtonLabel` type and `button` helper in [button.ts](https://github.com/elianiva/foldcn/pull/30/files#diff-c6ac6ab9a011561f91d52ac34f68d014caa366a20ef94b1873c3f7721f186a0e) to accept arrays of child nodes directly, removing intermediate `<span>` wrappers.
> - Updates button demos in [button.ts](https://github.com/elianiva/foldcn/pull/30/files#diff-e5a5435785af489cd928eefc6dd56a3ad9fd6c3618e02c9aa724fb75fa5e93be) to pass icon positions and use array labels.
> - Behavioral Change: Button demos no longer render intermediate `<span>` wrappers for labels, and rendered icons include a `data-icon` attribute indicating their position.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e531796.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->