### PR TITLE
fix: use InputGroup in Command input

### DIFF
--- a/packages/registry/registry/default/ui/command.ts
+++ b/packages/registry/registry/default/ui/command.ts
@@ -7,6 +7,7 @@ import type { Html, HtmlBuilder } from 'foldkit/html'
 import { cn } from '@/lib/utils'
 import { icon } from '@/lib/icons'
 import { Search } from 'lucide'
+import { inputGroup, inputGroupAddon, inputGroupInput } from './input-group'
 
 type Child = Html | string
 
@@ -38,6 +39,7 @@ export const commandSeparatorClass = 'cn-command-separator'
 export const commandShortcutClass = 'cn-command-shortcut'
 
 export type CommandInputConfig<M> = Readonly<{
+  id?: string
   value?: string
   onInput?: (value: string) => M
   placeholder?: string
@@ -58,20 +60,25 @@ const commandInput = <M>(config: CommandInputConfig<M>, h: HtmlBuilder<M>): Html
   h.div(
     [h.Class(cn('cn-command-input-wrapper')), h.DataAttribute('slot', 'command-input-wrapper')],
     [
-      h.div(
-        [h.Class(cn('cn-command-input-group'))],
+      inputGroup(
+        { className: 'cn-command-input-group' },
         [
-          icon(h, Search, 'cn-command-input-icon size-4 shrink-0 opacity-50'),
-          h.input([
-            h.Type('text'),
-            ...(config.value === undefined ? [] : [h.Value(config.value)]),
-            ...(config.isDisabled === true ? [h.Disabled(true)] : []),
-            ...(config.placeholder === undefined ? [] : [h.Placeholder(config.placeholder)]),
-            ...(config.onInput === undefined ? [] : [h.OnInput(config.onInput)]),
-            h.Class(cn(commandInputClass, config.className)),
-            h.DataAttribute('slot', 'command-input'),
-          ]),
+          inputGroupAddon({}, [icon(h, Search, 'cn-command-input-icon')], h),
+          inputGroupInput(
+            {
+              id: config.id ?? 'command-input',
+              ariaLabel: 'Search commands',
+              onInput: config.onInput,
+              value: config.value,
+              isDisabled: config.isDisabled,
+              placeholder: config.placeholder,
+              className: cn(commandInputClass, config.className),
+              attributes: [h.DataAttribute('slot', 'command-input')],
+            },
+            h,
+          ),
         ],
+        h,
       ),
     ],
   )

--- a/packages/registry/registry/default/ui/input-group.ts
+++ b/packages/registry/registry/default/ui/input-group.ts
@@ -85,6 +85,7 @@ export const inputGroupTextarea = <M>(
 
 export type InputGroupInputConfig<M> = Readonly<{
   id: string
+  ariaLabel?: string
   value?: string
   onInput?: (value: string) => M
   isDisabled?: boolean
@@ -103,6 +104,7 @@ export type InputGroupInputConfig<M> = Readonly<{
 export const inputGroupInput = <M>(config: InputGroupInputConfig<M>, h: HtmlBuilder<M>): Html =>
   h.input([
     h.Id(config.id),
+    ...(config.ariaLabel === undefined ? [] : [h.AriaLabel(config.ariaLabel)]),
     ...(config.onInput === undefined ? [] : [h.OnInput(config.onInput)]),
     ...(config.value === undefined ? [] : [h.Value(config.value)]),
     ...(config.isDisabled === true ? [h.Disabled(true), h.DataAttribute('disabled', '')] : []),


### PR DESCRIPTION
## What

Use Foldcn `InputGroup` primitives for `Command.input`: `inputGroup`, `inputGroupAddon`, and `inputGroupInput`. The Search icon now uses the addon slot, and the command input keeps its command slot and accessible label.

## Why

The previous command input placed the icon beside a native input. Using the existing InputGroup contract gives the icon the intended addon spacing and focus styling.

## Validation

- `pnpm typecheck` passes
- `pnpm test` passes (11 tests)
- `pnpm validate` passes
- `pnpm --filter @foldcn/registry run build` passes
- Changed-file formatting and lint pass

## CI note

Full `pnpm lint` currently fails on an unrelated existing unused import: `componentCount` in `packages/web/src/page/chrome.ts:19`. This change does not touch that file.

How would you like to handle that existing CI failure: fix it in this PR, or leave it for a separate cleanup PR?


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace ad-hoc div markup with `inputGroup` in `commandInput`
> - `commandInput` now renders via `inputGroup()`, `inputGroupAddon()`, and `inputGroupInput()` instead of a hand-rolled div structure.
> - `InputGroupInputConfig` gains an optional `ariaLabel` field, which `inputGroupInput` emits as `h.AriaLabel`.
> - `CommandInputConfig` gains an optional `id`; the input defaults to `id='command-input'` and `aria-label='Search commands'` when not provided.
> - Behavioral Change: the command input DOM structure and class composition differ from before; the element now emits `data-slot='input-group-control'` in addition to `data-slot='command-input'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized abbd9da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->