### PR TITLE
Merge pstack into the Cloud Agent install script

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,6 +1,6 @@
 {
   "name": "foldcn",
-  "install": "pnpm install --frozen-lockfile",
+  "install": "set -euo pipefail\n# Prefer nvm Node 22.22.3 when present; otherwise the latest nvm v22 on this image.\nif [ -d \"$HOME/.nvm/versions/node/v22.22.3/bin\" ]; then\n  export PATH=\"$HOME/.nvm/versions/node/v22.22.3/bin:$PATH\"\nelse\n  nvm_node_bin=\"$(ls -d \"$HOME/.nvm/versions/node\"/v22.*/bin 2>/dev/null | sort -V | tail -n1 || true)\"\n  if [ -n \"$nvm_node_bin\" ]; then\n    export PATH=\"$nvm_node_bin:$PATH\"\n  fi\nfi\npnpm install --frozen-lockfile\n# pstack: home directory only, never the foldcn checkout\nmkdir -p \"$HOME/.cursor/plugins\" \"$HOME/.cursor/skills\"\nif [ ! -d \"$HOME/.cache/cursor-plugins/.git\" ]; then\n  git clone --depth 1 --filter=blob:none --sparse https://github.com/cursor/plugins.git \"$HOME/.cache/cursor-plugins\"\nfi\ngit -C \"$HOME/.cache/cursor-plugins\" fetch --depth 1 origin\ngit -C \"$HOME/.cache/cursor-plugins\" reset --hard origin/HEAD\ngit -C \"$HOME/.cache/cursor-plugins\" sparse-checkout set pstack\nrm -rf \"$HOME/.cursor/plugins/pstack\"\ncp -a \"$HOME/.cache/cursor-plugins/pstack\" \"$HOME/.cursor/plugins/pstack\"\nshopt -s nullglob\nfor skill_dir in \"$HOME/.cursor/plugins/pstack/skills\"/*/; do\n  ln -sfn \"$skill_dir\" \"$HOME/.cursor/skills/$(basename \"$skill_dir\")\"\ndone\n",
   "terminals": [
     {
       "name": "web",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Merge the home-directory pstack plugin setup into foldcn’s Cloud Agent install while keeping the existing `pnpm install --frozen-lockfile` bootstrap.

This environment is dashboard-managed (personal). Updating `.cursor/environment.json` keeps the repo copy in sync; the live Cloud Agent environment still needs **Save** on the Environment panel after the draft build is proposed.

Changes:
- Keep frozen-lockfile `pnpm install`
- Prefer nvm Node `v22.22.3` when present, otherwise the latest nvm v22 on the image (this snapshot currently has `v22.22.2`)
- Sparse-clone `cursor/plugins` pstack into `$HOME/.cursor/plugins/pstack` and symlink skills into `$HOME/.cursor/skills`
- Never copy pstack into the foldcn checkout
- Leave the web terminal on port 5173 unchanged

Foldkit’s `scripts/cloud-session-setup.sh` is not used: that script is foldkit-specific (stale overlay cleanup + package dist builds) and is not in this repo. The foldcn equivalent remains `pnpm install --frozen-lockfile`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32e0afd2-c48b-4204-9c74-ee06df09ab71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32e0afd2-c48b-4204-9c74-ee06df09ab71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `pstack` plugin install and nvm Node v22 setup to Cloud Agent install script
> - Replaces the single install command in [environment.json](https://github.com/elianiva/foldcn/pull/33/files#diff-e1ffd6d714c0489804c88c05dc0d8d38fb427117251b73e8c4a3a4401c5cdb9e) with a multi-line shell script that runs `pnpm install --frozen-lockfile` and then installs the `pstack` plugin
> - Configures PATH to prefer an nvm-managed Node v22.22.3, falling back to the latest available nvm v22.x
> - Clones or updates the `cursor/plugins` repo with sparse checkout for `pstack`, resets to `origin/HEAD`, copies it into `~/.cursor/plugins/pstack`, and symlinks each skill into `~/.cursor/skills`
> - Enables strict shell options (`set -euo pipefail`) so the install fails fast on errors or unset variables
> - Behavioral Change: install now requires `nvm` and `git` to be available; missing `nvm` or failure to fetch the plugins repo will abort the install
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da0edd3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->