### PR TITLE
fix(ui): Change hover card to use Hover Intent UI

### DIFF
--- a/packages/registry/registry/default/ui/hover-card.ts
+++ b/packages/registry/registry/default/ui/hover-card.ts
@@ -1,55 +1,31 @@
-/** Hover card — opens on pointer hover (200ms) and closes after 300ms grace; focus opens immediately.
- *  The styled surface matches upstream shadcn; hover-intent/grace is implemented via
- *  200/300ms delays and hover-zone handlers (trigger + panel). */
 /** Stateful submodel — import the whole module as a namespace and wire its
  *  Model/Message/init/update into your app:
  *  `import * as HoverCard from '@/components/ui/hover-card'`
  */
-import { Duration, Effect, Match as M, Option, Schema as S } from 'effect'
-import * as Command from 'foldkit/command'
+import { HoverIntent, Popover as FoldkitPopover } from '@foldkit/ui'
 import type { AnchorConfig } from '@foldkit/ui/anchor'
-import { Popover as FoldkitPopover } from '@foldkit/ui'
-import { childAttributes, type ChildAttribute } from 'foldkit/html'
-import type { Html, HtmlBuilder } from 'foldkit/html'
+import { Duration, Match as M, Option, Schema as S } from 'effect'
+import * as Command from 'foldkit/command'
+import { childAttributes, type ChildAttribute, type Html, type HtmlBuilder } from 'foldkit/html'
 import { defineMessageUnion } from 'foldkit/message'
 import { evo } from 'foldkit/struct'
 import { defineView } from 'foldkit/submodel'
 import * as Update from 'foldkit/update'
 
-type Child = Html | string
-
 import { cn } from '@/lib/utils'
 
-// A real hover card: opens on pointer hover (after `openDelay`), stays open
-// while the pointer crosses the trigger-to-panel gap or moves into the panel,
-// and closes after `closeDelay` once the pointer leaves both. Keyboard users
-// get the same card via trigger focus. Built by embedding the @foldkit/ui
-// Popover submodel — it supplies positioning (Floating UI), the enter/leave
-// animation lifecycle, and Escape handling; this module adds the hover state
-// machine and renders the popover headlessly (no backdrop, no click toggle).
+type Child = Html | string
 
+/** HoverIntent owns delayed pointer/focus engagement; Popover supplies the
+ * floating anchor and enter/leave lifecycle. */
 export const Model = S.Struct({
+  hoverIntent: HoverIntent.Model,
   popover: FoldkitPopover.Model,
-  isPointerOverCard: S.Boolean,
-  isTriggerFocused: S.Boolean,
-  pendingShowVersion: S.Number,
-  pendingHideVersion: S.Number,
-  openDelay: S.DurationFromMillis,
-  closeDelay: S.DurationFromMillis,
 })
 export type Model = typeof Model.Type
 
-const DEFAULT_OPEN_DELAY_MS = 200
-const DEFAULT_CLOSE_DELAY_MS = 300
-
 export const Message = defineMessageUnion({
-  EnteredHoverZone: {},
-  LeftHoverZone: {},
-  FocusedTrigger: {},
-  BlurredTrigger: {},
-  PressedEscape: {},
-  CompletedWaitBeforeShow: { version: S.Number },
-  CompletedWaitBeforeHide: { version: S.Number },
+  GotHoverIntentMessage: { message: HoverIntent.Message },
   GotPopoverMessage: { message: FoldkitPopover.Message },
 })
 export type Message = typeof Message.Type
@@ -67,26 +43,16 @@ export type InitConfig = Readonly<{
   isAnimated?: boolean
 }>
 
-/** Creates an initial hover-card model from a config. Defaults to closed,
- *  200ms open delay, 300ms close delay, animated. */
 export const init = (config: InitConfig): Model => ({
+  hoverIntent: HoverIntent.init({
+    ...(config.openDelay === undefined ? {} : { openDelay: config.openDelay }),
+    ...(config.closeDelay === undefined ? {} : { closeDelay: config.closeDelay }),
+  }),
   popover: FoldkitPopover.init({
     id: config.id,
     isAnimated: config.isAnimated ?? true,
     contentFocus: true,
   }),
-  isPointerOverCard: false,
-  isTriggerFocused: false,
-  pendingShowVersion: 0,
-  pendingHideVersion: 0,
-  openDelay:
-    config.openDelay === undefined
-      ? Duration.millis(DEFAULT_OPEN_DELAY_MS)
-      : Duration.fromInputUnsafe(config.openDelay),
-  closeDelay:
-    config.closeDelay === undefined
-      ? Duration.millis(DEFAULT_CLOSE_DELAY_MS)
-      : Duration.fromInputUnsafe(config.closeDelay),
 })
 
 export const HOVER_CARD_ANCHOR: AnchorConfig = {
@@ -101,15 +67,10 @@ export const hoverCardTriggerClass =
 export const hoverCardContentClass =
   'cn-hover-card-content cn-hover-card-content-logical z-50 origin-(--transform-origin) outline-hidden'
 
-/** Kept for backward compatibility — animations now live in the token. */
 export const hoverCardContentAnimatedClass = hoverCardContentClass
-
 export const hoverCardWrapperClass = 'relative inline-block'
-
 export const hoverCardHeaderClass = 'cn-popover-header'
-
 export const hoverCardTitleClass = 'cn-popover-title'
-
 export const hoverCardDescriptionClass = 'cn-popover-description'
 
 type StyleConfig = Readonly<{ className?: string }>
@@ -153,181 +114,84 @@ export const description = <M>(
     children,
   )
 
-// Kept for API parity with other registry items. The trigger is the embedded
-// popover's button.
 export const buttonId = FoldkitPopover.buttonId
 
 type UpdateReturn = Update.ReturnWithOutMessage<Model, Message, OutMessage>
 
-/** Waits for the open delay before emitting `CompletedWaitBeforeShow`.
- *  Stale invocations are filtered by version in update. */
-const WaitBeforeShow = Command.define('WaitBeforeShow', {
-  args: { delay: S.DurationFromMillis, version: S.Number },
-  messages: [Message.CompletedWaitBeforeShow],
-  execute: ({ delay, version }) =>
-    Effect.sleep(delay).pipe(Effect.as(Message.CompletedWaitBeforeShow({ version }))),
-})
-
-/** Waits for the close delay before emitting `CompletedWaitBeforeHide`.
- *  This grace period is what lets the pointer cross the trigger-to-panel
- *  gap without closing the card. */
-const WaitBeforeHide = Command.define('WaitBeforeHide', {
-  args: { delay: S.DurationFromMillis, version: S.Number },
-  messages: [Message.CompletedWaitBeforeHide],
-  execute: ({ delay, version }) =>
-    Effect.sleep(delay).pipe(Effect.as(Message.CompletedWaitBeforeHide({ version }))),
-})
-
-const isOpen = (model: Model): boolean => model.popover.isOpen
+const toGotHoverIntentMessage = (message: HoverIntent.Message): Message =>
+  Message.GotHoverIntentMessage({ message })
 
 const toGotPopoverMessage = (message: FoldkitPopover.Message): Message =>
   Message.GotPopoverMessage({ message })
 
-const foldPopover = Update.foldChild({
-  update: FoldkitPopover.update,
-  read: (model: Model) => Option.some(model.popover),
-  write: (model, nextPopover) => evo(model, { popover: () => nextPopover }),
-  toParentMessage: toGotPopoverMessage,
-  toParentOutMessage: (outMessage: FoldkitPopover.OutMessage): OutMessage =>
-    outMessage._tag === 'Opened' ? OutMessage.Opened() : OutMessage.Closed(),
+const mapPopoverCommands = (
+  commands: NonNullable<ReturnType<typeof FoldkitPopover.open>['commands']> = [],
+) => Command.mapMessages(commands.filter((command) => command.name !== 'FocusButton'), toGotPopoverMessage)
+
+const syncPopover = (
+  model: Model,
+  operation: typeof FoldkitPopover.open | typeof FoldkitPopover.close,
+  outMessage: OutMessage,
+): UpdateReturn => {
+  const result = operation(model.popover)
+  return {
+    model: evo(model, { popover: () => result.model }),
+    commands: mapPopoverCommands(result.commands),
+    outMessage,
+  }
+}
+
+const foldHoverIntentOutMessage = M.type<HoverIntent.OutMessage>().pipe(
+  M.withReturnType<Update.StepWithOutMessage<Model, Message, OutMessage>>(),
+  M.tagsExhaustive({
+    Opened: () => (model) => syncPopover(model, FoldkitPopover.open, OutMessage.Opened()),
+    Closed: () => (model) => syncPopover(model, FoldkitPopover.close, OutMessage.Closed()),
+  }),
+)
+
+const foldHoverIntent = Update.foldChild({
+  update: HoverIntent.update,
+  read: (model: Model) => Option.some(model.hoverIntent),
+  write: (model, hoverIntent) => evo(model, { hoverIntent: () => hoverIntent }),
+  toParentMessage: toGotHoverIntentMessage,
+  foldOutMessage: foldHoverIntentOutMessage,
 })
 
-const scheduleShow = (model: Model): UpdateReturn => {
-  const version = model.pendingShowVersion + 1
-  return {
-    model: evo(model, { pendingShowVersion: () => version }),
-    commands: [WaitBeforeShow({ delay: model.openDelay, version })],
-  }
-}
+const releaseTriggerFocus = (model: Model): Model =>
+  evo(model, {
+    hoverIntent: (hoverIntent) =>
+      evo(hoverIntent, {
+        maybeFocusLocation: () =>
+          Option.filter(hoverIntent.maybeFocusLocation, (location) => location !== 'Trigger'),
+      }),
+  })
 
-const scheduleHide = (model: Model): UpdateReturn => {
-  const version = model.pendingHideVersion + 1
-  return {
-    model: evo(model, { pendingHideVersion: () => version }),
-    commands: [WaitBeforeHide({ delay: model.closeDelay, version })],
-  }
-}
-
-const openNow = (model: Model): UpdateReturn => {
-  const { model: nextPopover, commands: popoverCommands = [] } = FoldkitPopover.open(model.popover)
-  return {
-    model: evo(model, { popover: () => nextPopover }),
-    commands: Command.mapMessages(popoverCommands, toGotPopoverMessage),
-    outMessage: OutMessage.Opened(),
-  }
-}
-
-const closeNow = (model: Model): UpdateReturn => {
-  // Close through update rather than `FoldkitPopover.close`, then drop the
-  // FocusButton command: a pointer- or blur-driven dismissal must not yank
-  // focus back to the trigger — the returned focus would fire FocusedTrigger
-  // and immediately re-open the card.
-  const { model: nextPopover, commands: popoverCommands = [] } = FoldkitPopover.update(
-    model.popover,
-    FoldkitPopover.Message.RequestedClose(),
-  )
-  return {
-    model: evo(model, { popover: () => nextPopover }),
-    commands: Command.mapMessages(
-      popoverCommands.filter((command) => command.name !== 'FocusButton'),
-      toGotPopoverMessage,
-    ),
-    outMessage: OutMessage.Closed(),
-  }
-}
-
-const withUpdateReturn = M.withReturnType<UpdateReturn>()
-
-/** Processes a hover-card message and returns the next model, commands, and
- *  an optional OutMessage. `Opened`/`Closed` fire only on visibility
- *  transitions. */
 export const update = (model: Model, message: Message): UpdateReturn =>
   M.value(message).pipe(
-    withUpdateReturn,
+    M.withReturnType<UpdateReturn>(),
     M.tagsExhaustive({
-      EnteredHoverZone: () => {
-        // Re-entering cancels any pending close.
-        const entered = evo(model, {
-          isPointerOverCard: () => true,
-          pendingHideVersion: () => model.pendingHideVersion + 1,
-        })
-        if (isOpen(entered)) {
-          return { model: entered }
-        }
-        return scheduleShow(entered)
-      },
-      LeftHoverZone: () => {
-        const left = evo(model, {
-          isPointerOverCard: () => false,
-          pendingShowVersion: () => model.pendingShowVersion + 1,
-        })
-        // Focus keeps the card open until blur.
-        if (!isOpen(left) || left.isTriggerFocused) {
-          return { model: left }
-        }
-        return scheduleHide(left)
-      },
-      FocusedTrigger: () => {
-        const focused = evo(model, {
-          isTriggerFocused: () => true,
-          pendingShowVersion: () => model.pendingShowVersion + 1,
-          pendingHideVersion: () => model.pendingHideVersion + 1,
-        })
-        if (isOpen(focused)) {
-          return { model: focused }
-        }
-        // Focus opens immediately, without the hover delay.
-        return openNow(focused)
-      },
-      BlurredTrigger: () => {
-        const blurred = evo(model, {
-          isTriggerFocused: () => false,
-          pendingShowVersion: () => model.pendingShowVersion + 1,
-        })
-        // Hover keeps the card open until leave.
-        if (!isOpen(blurred) || blurred.isPointerOverCard) {
-          return { model: blurred }
-        }
-        return scheduleHide(blurred)
-      },
-      PressedEscape: () =>
-        closeNow(
-          evo(model, {
-            pendingShowVersion: () => model.pendingShowVersion + 1,
-            pendingHideVersion: () => model.pendingHideVersion + 1,
+      GotHoverIntentMessage: ({ message: hoverIntentMessage }) =>
+        hoverIntentMessage._tag === 'FocusedPanel' || hoverIntentMessage._tag === 'BlurredPanel'
+          ? { model }
+          : foldHoverIntent(
+              hoverIntentMessage._tag === 'LeftTrigger' ? releaseTriggerFocus(model) : model,
+              hoverIntentMessage,
+            ),
+      GotPopoverMessage: ({ message: popoverMessage }) => {
+        const result = FoldkitPopover.update(model.popover, popoverMessage)
+        const hoverIntent =
+          popoverMessage._tag === 'RequestedClose'
+            ? HoverIntent.close(model.hoverIntent)
+            : { model: model.hoverIntent }
+        return {
+          model: evo(model, {
+            hoverIntent: () => hoverIntent.model,
+            popover: () => result.model,
           }),
-        ),
-      CompletedWaitBeforeShow: ({ version }) => {
-        if (version !== model.pendingShowVersion || !model.isPointerOverCard || isOpen(model)) {
-          return { model }
+          commands: mapPopoverCommands(result.commands),
+          ...(hoverIntent.outMessage === undefined ? {} : { outMessage: hoverIntent.outMessage }),
         }
-        return openNow(model)
       },
-      CompletedWaitBeforeHide: ({ version }) => {
-        if (version !== model.pendingHideVersion || model.isPointerOverCard || !isOpen(model)) {
-          return { model }
-        }
-        return closeNow(model)
-      },
-      GotPopoverMessage: ({ message: popoverMessage }) => foldPopover(model, popoverMessage),
-    }),
-  )
-
-/** Programmatically opens the hover card, cancelling pending timers. */
-export const open = (model: Model): UpdateReturn =>
-  openNow(
-    evo(model, {
-      pendingShowVersion: () => model.pendingShowVersion + 1,
-      pendingHideVersion: () => model.pendingHideVersion + 1,
-    }),
-  )
-
-/** Programmatically closes the hover card, cancelling pending timers. */
-export const close = (model: Model): UpdateReturn =>
-  closeNow(
-    evo(model, {
-      pendingShowVersion: () => model.pendingShowVersion + 1,
-      pendingHideVersion: () => model.pendingHideVersion + 1,
     }),
   )
 
@@ -339,93 +203,86 @@ export type ViewInputs = Readonly<{
   ariaLabelledBy?: string
 }>
 
-/** Render-time payload published to the consumer's `toView`.
- *
- *  - `trigger`: attribute bundle for the trigger button. Carries the
- *    hover/focus handlers and ARIA linkage to the panel. Click-toggle
- *    handlers are stripped: a hover card opens on hover/focus only.
- *  - `panel`: attribute bundle for the floating interactive panel. Carries
- *    the anchor Mount (Floating UI positioning), animation lifecycle
- *    attributes, Escape handling, and the hover-zone handlers that keep the
- *    card open while the pointer is over the panel.
- *  - `isVisible`: derived from the popover's open state and leave-animation
- *    lifecycle. Render the panel only while this is true. */
 export type RenderInfo = Readonly<{
   trigger: ReadonlyArray<ChildAttribute>
   panel: ReadonlyArray<ChildAttribute>
+  backdrop: ReadonlyArray<ChildAttribute>
   isVisible: boolean
 }>
 
-/** The popover's button bundle toggles on press/click — right for a popover,
- *  wrong for a hover card. Strip those handlers so clicking the trigger does
- *  nothing (matching shadcn), keeping keyboard activation. */
-const withoutClickToggle = (button: ReadonlyArray<ChildAttribute>): ReadonlyArray<ChildAttribute> =>
-  button.filter((wrapped) => {
+/** Popover has click-toggle handlers; HoverIntent exclusively owns interaction. */
+const withoutPopoverInteractions = (
+  attributes: ReadonlyArray<ChildAttribute>,
+): ReadonlyArray<ChildAttribute> =>
+  attributes.filter((wrapped) => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const tag = (wrapped.attribute as { readonly _tag?: string } | undefined)?._tag
-    return tag !== 'OnPointerDown' && tag !== 'OnClick'
+    return ![
+      'OnPointerDown',
+      'OnClick',
+      'OnKeyDownPreventDefault',
+      'OnKeyUpPreventDefault',
+    ].includes(tag ?? '')
   })
 
-/** Renders the hover card headlessly by embedding the Popover submodel. */
 export const view = defineView<Model, Message, ViewInputs>((model, viewInputs, h) => {
   const { anchor, toView, isDisabled, ariaLabel, ariaLabelledBy } = viewInputs
 
-  const hoverZoneHandlers = isDisabled
-    ? []
-    : [h.OnMouseEnter(Message.EnteredHoverZone()), h.OnMouseLeave(Message.LeftHoverZone())]
-  const triggerFocusHandlers = isDisabled
-    ? []
-    : [
-        h.OnFocus(Message.FocusedTrigger()),
-        h.OnBlur(Message.BlurredTrigger()),
-        h.OnKeyDownPreventDefault((key) =>
-          key === 'Escape' && model.popover.isOpen
-            ? Option.some(Message.PressedEscape())
-            : Option.none(),
-        ),
-      ]
-
   return h.submodel({
-    slotId: model.popover.id,
-    model: model.popover,
-    view: FoldkitPopover.view,
+    slotId: `${model.popover.id}-hover-intent`,
+    model: model.hoverIntent,
+    view: HoverIntent.view,
     viewInputs: {
-      anchor,
-      ...(isDisabled !== undefined && { isDisabled }),
-      ...(ariaLabel !== undefined && { ariaLabel }),
-      ...(ariaLabelledBy !== undefined && { ariaLabelledBy }),
-      toView: ({ button, panel, isVisible }) =>
-        toView({
-          // The popover's bundles are already boundary-wrapped; only our own
-          // attributes need wrapping, so the two arrays are concatenated.
-          trigger: [
-            ...withoutClickToggle(button),
-            ...childAttributes([
-              h.AriaDescribedBy(`${model.popover.id}-panel`),
-              h.DataAttribute('slot', 'hover-card-trigger'),
-              ...triggerFocusHandlers,
-              ...hoverZoneHandlers,
-            ]),
-          ],
-          panel: [
-            ...panel,
-            ...childAttributes([
-              h.DataAttribute('slot', 'hover-card-content'),
-              ...hoverZoneHandlers,
-            ]),
-          ],
-          isVisible,
+      focusTriggerSelector: `#${FoldkitPopover.buttonId(model.popover.id)}`,
+      toView: ({ trigger, panel }) =>
+        h.submodel({
+          slotId: `${model.popover.id}-popover`,
+          model: model.popover,
+          view: FoldkitPopover.view,
+          viewInputs: {
+            anchor,
+            ...(isDisabled === undefined ? {} : { isDisabled }),
+            ...(ariaLabel === undefined ? {} : { ariaLabel }),
+            ...(ariaLabelledBy === undefined ? {} : { ariaLabelledBy }),
+            toView: ({ button, panel: popoverPanel, backdrop, isVisible }) =>
+              toView({
+                trigger: [
+                  ...withoutPopoverInteractions(button),
+                  ...(isDisabled ? [] : trigger),
+                  ...childAttributes([
+                    h.AriaDescribedBy(`${model.popover.id}-panel`),
+                    h.DataAttribute('slot', 'hover-card-trigger'),
+                  ]),
+                ],
+                panel: [
+                  ...withoutPopoverInteractions(popoverPanel),
+                  ...(isDisabled ? [] : panel),
+                  ...childAttributes([h.DataAttribute('slot', 'hover-card-content')]),
+                ],
+                backdrop: [
+                  ...withoutPopoverInteractions(backdrop),
+                  ...childAttributes([
+                    h.OnClick(
+                      Message.GotPopoverMessage({
+                        message: FoldkitPopover.Message.RequestedClose(),
+                      }),
+                    ),
+                    h.DataAttribute('slot', 'hover-card-backdrop'),
+                  ]),
+                ],
+                isVisible,
+              }),
+          },
+          toParentMessage: toGotPopoverMessage,
         }),
     },
-    toParentMessage: toGotPopoverMessage,
+    toParentMessage: toGotHoverIntentMessage,
   })
 })
 
 export type StyledViewInputs = Readonly<{
   anchor?: AnchorConfig
-  /** Trigger button face. */
   trigger: Child
-  /** Panel content. */
   content: ReadonlyArray<Child>
   isDisabled?: boolean
   ariaLabel?: string
@@ -437,8 +294,6 @@ export type StyledViewInputs = Readonly<{
   isAnimated?: boolean
 }>
 
-/** Build styled `ViewInputs` for the hover card. Pass your view's `h` so the
- *  trigger and content can dispatch your app's own messages. */
 export const styledViewInputs = <AppMessage>(
   viewInputs: StyledViewInputs,
   h: HtmlBuilder<AppMessage>,
@@ -447,7 +302,7 @@ export const styledViewInputs = <AppMessage>(
   isDisabled: viewInputs.isDisabled,
   ariaLabel: viewInputs.ariaLabel,
   ariaLabelledBy: viewInputs.ariaLabelledBy,
-  toView: ({ trigger, panel, isVisible }) =>
+  toView: ({ trigger, panel, backdrop, isVisible }) =>
     h.div(
       [
         h.Class(cn(hoverCardWrapperClass, viewInputs.wrapperClass)),
@@ -460,6 +315,7 @@ export const styledViewInputs = <AppMessage>(
         ),
         ...(isVisible
           ? [
+              h.div([...backdrop, h.Class('fixed inset-0 z-0')]),
               h.div(
                 [
                   ...panel,

--- a/packages/registry/registry/default/ui/hover-card.ts
+++ b/packages/registry/registry/default/ui/hover-card.ts
@@ -126,7 +126,11 @@ const toGotPopoverMessage = (message: FoldkitPopover.Message): Message =>
 
 const mapPopoverCommands = (
   commands: NonNullable<ReturnType<typeof FoldkitPopover.open>['commands']> = [],
-) => Command.mapMessages(commands.filter((command) => command.name !== 'FocusButton'), toGotPopoverMessage)
+) =>
+  Command.mapMessages(
+    commands.filter((command) => command.name !== 'FocusButton'),
+    toGotPopoverMessage,
+  )
 
 const syncPopover = (
   model: Model,

--- a/packages/registry/registry/default/ui/registry.json
+++ b/packages/registry/registry/default/ui/registry.json
@@ -594,7 +594,7 @@
       "name": "hover-card",
       "type": "registry:ui",
       "title": "Hover Card",
-      "description": "Card-styled floating panel with hover-intent open/close delays (200ms open, 300ms grace). Built on the @foldkit/ui Popover submodel with a hand-rolled hover state machine — not a shared foldkit/ui hover primitive.",
+      "description": "Card-styled floating panel with hover-intent open/close delays (200ms open, 300ms grace), built from @foldkit/ui HoverIntent and Popover.",
       "registryDependencies": ["@foldcn/utils"],
       "files": [
         {

--- a/packages/web/src/catalog/gaps.ts
+++ b/packages/web/src/catalog/gaps.ts
@@ -19,9 +19,6 @@ export const gapsByItem: Readonly<Record<string, ReadonlyArray<string>>> = {
   'context-menu': [
     'Opens on activation at a fixed anchor — foldkit has no right-click/pointer-position anchoring primitive yet.',
   ],
-  'hover-card': [
-    'Hover-intent is hand-rolled in this component, not a shared foldkit/ui primitive — copy it along if you need the same behavior elsewhere.',
-  ],
   sidebar: [
     'No cookie persistence — foldkit owns initial render through its own hydration rather than document.cookie (an SSR flash-prevention mechanism).',
     'Collapsed-mode menu-button tooltips are not auto-composed — wrap menu buttons in Tooltip submodels yourself if you need them.',

--- a/packages/web/src/demo/views/hover-card.ts
+++ b/packages/web/src/demo/views/hover-card.ts
@@ -12,6 +12,7 @@ import type { Model, Message as AppMessage } from '../assemble'
 
 const Message = defineMessageUnion({
   GotHoverCardMessage: { message: HoverCard.Message },
+  GotDelayedHoverCardMessage: { message: HoverCard.Message },
 })
 
 export const hoverCardView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
@@ -31,7 +32,7 @@ export const hoverCardView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
                 trigger: 'Hover Here',
                 content: [
                   h.div(
-                    [h.Class('flex flex-col gap-0.5 w-64')],
+                    [h.Class('flex flex-col gap-0.5')],
                     [
                       h.div([h.Class('font-semibold')], ['@nextjs']),
                       h.div(
@@ -57,10 +58,25 @@ export const hoverCardView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
         [h.Class('flex w-full flex-col gap-2')],
         [
           h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], ['With Delay']),
-          h.div(
-            [h.Class('mx-auto w-full max-w-sm rounded-lg border p-4 text-sm')],
-            [h.p([], ['Hover card with open/close delay.'])],
-          ),
+          h.submodel({
+            slotId: model.delayedHoverCard.popover.id,
+            model: model.delayedHoverCard,
+            view: HoverCard.view,
+            viewInputs: HoverCard.styledViewInputs(
+              {
+                trigger: 'Hover with delay',
+                content: [
+                  h.p(
+                    [h.Class('text-sm')],
+                    ['Opens after 500ms and closes 300ms after leaving the card.'],
+                  ),
+                ],
+                contentClass: 'w-64',
+              },
+              h,
+            ),
+            toParentMessage: (message) => Message.GotDelayedHoverCardMessage({ message }),
+          }),
         ],
       ),
     ],
@@ -87,18 +103,32 @@ const foldHoverCard = Update.foldChild({
   foldOutMessage: foldHoverCardOutMessage,
 })
 
-const fields = { hoverCard: HoverCard.Model }
+const foldDelayedHoverCard = Update.foldChild({
+  update: HoverCard.update,
+  read: (model: State) => Option.some(model.delayedHoverCard),
+  write: (model, next) => evo(model, { delayedHoverCard: () => next }),
+  toParentMessage: (message) => Message.GotDelayedHoverCardMessage({ message }),
+  foldOutMessage: foldHoverCardOutMessage,
+})
+
+const fields = { hoverCard: HoverCard.Model, delayedHoverCard: HoverCard.Model }
 
 const stateSchema = S.Struct(fields)
 type State = typeof stateSchema.Type
 
 export const slice = defineSlice({
   fields,
-  init: { hoverCard: HoverCard.init({ id: 'hover-card-demo' }) },
-  messages: [Message.GotHoverCardMessage],
+  init: {
+    hoverCard: HoverCard.init({ id: 'hover-card-demo' }),
+    delayedHoverCard: HoverCard.init({ id: 'hover-card-delay-demo', openDelay: 500 }),
+  },
+  messages: [Message.GotHoverCardMessage, Message.GotDelayedHoverCardMessage],
   handlers: (model: State) => ({
     GotHoverCardMessage: (payload: typeof Message.GotHoverCardMessage.Type): UpdateReturn =>
       foldHoverCard(model, payload.message),
+    GotDelayedHoverCardMessage: (
+      payload: typeof Message.GotDelayedHoverCardMessage.Type,
+    ): UpdateReturn => foldDelayedHoverCard(model, payload.message),
   }),
   samples: [],
   // Open/close flows entirely through the submodel (hover, focus, Escape);


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Replace hand-rolled hover-intent in `hover-card.ts` with shared `HoverIntent` submodel
- Rewrites the hover-card model to delegate hover/focus/escape logic to the shared `@foldkit/ui` `HoverIntent` submodel, which now drives `Popover` visibility through its `Opened`/`Closed` out-messages
- Removes the exported `open()` and `close()` functions; interaction is owned exclusively by `HoverIntent`, and `Popover` click/keyboard handlers are stripped from the trigger and panel
- Adds a fixed-position backdrop element rendered when the card is visible; clicking it requests close
- `FocusButton` command from `Popover` is filtered out so close no longer re-focuses the trigger, preventing reopen loops
- Updates the demo in [hover-card.ts](https://github.com/elianiva/foldcn/pull/34/files#diff-c51373bd9abd7d585e5dfbe5765af851ab17484149e83444d31d6a356f7bff5c) to wire a second `hover-card` instance with a 500ms `openDelay` instead of static placeholder text
- Removes the stale hover-card gap note from [gaps.ts](https://github.com/elianiva/foldcn/pull/34/files#diff-e8174ee74a37f9be2fca805de4040d58eb524639f14bccccebbb5b032c6f8e04)
- Behavioral Change: the model shape, message union, and exported API all change — any direct consumer of the old fields (`isPointerOverCard`, `pendingShowVersion`, `openDelay`, etc.) or the `open()`/`close()` functions must migrate to `HoverIntent` delegation

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7631b7.</sup>
<!-- Macroscope's review summary ends here -->
<!-- Macroscope's pull request summary ends here -->