### PR TITLE
fix: persist sidebar state in cookie

### DIFF
--- a/packages/registry/registry/default/ui/sidebar.ts
+++ b/packages/registry/registry/default/ui/sidebar.ts
@@ -1,7 +1,3 @@
-/** ⚠ BEHAVIOR GAP vs upstream shadcn: no cookie/localStorage persistence of the collapsed state — seed it from your own persisted Model at init.
- *  The styled surface matches, but this behavior is absent — do not use
- *  where that behavior is required.
- */
 /** Stateful submodel — import the whole module as a namespace and wire its
  *  Model/Message/init/update into your app:
  *  `import * as Sidebar from '@/components/ui/sidebar'`
@@ -48,9 +44,7 @@ type Attributes<M> = ReadonlyArray<Attribute<M> | ChildAttribute>
 // derived collapse state; spread them onto any element to wire toggling
 // without lifting messages into your own universe.
 //
-// foldcn gaps vs upstream: no cookie persistence (an SSR flash-prevention
-// mechanism — foldkit owns initial render through its own hydration), and
-// collapsed-mode menu-button tooltips are not auto-composed (each would need
+// Collapsed-mode menu-button tooltips are not auto-composed (each would need
 // a per-item Tooltip submodel; wrap menu buttons yourself if you need them).
 // Controlled/uncontrolled `open` collapses into one mode: the model you pass
 // IS the state.
@@ -58,6 +52,8 @@ type Attributes<M> = ReadonlyArray<Attribute<M> | ChildAttribute>
 export const SIDEBAR_WIDTH = '16rem'
 export const SIDEBAR_WIDTH_MOBILE = '18rem'
 export const SIDEBAR_WIDTH_ICON = '3rem'
+export const SIDEBAR_COOKIE_NAME = 'sidebar_state'
+export const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
 export const SIDEBAR_KEYBOARD_SHORTCUT = 'b'
 
 /** Viewport below Tailwind's `md` breakpoint counts as mobile (upstream
@@ -75,6 +71,7 @@ export type Message = typeof Message.Type
 /** Sidebar state: desktop expansion, mobile viewport flag, and the mobile
  *  off-canvas Sheet submodel that owns the open-on-mobile presentation. */
 export const Model = S.Struct({
+  cookieName: S.String,
   isOpen: S.Boolean,
   isMobile: S.Boolean,
   sheet: Sheet.Model,
@@ -86,10 +83,17 @@ export type InitConfig = Readonly<{
   id: string
   /** Desktop initial expansion. Defaults to `true` like upstream. */
   defaultOpen?: boolean
+  /** Cookie used to persist the desktop expanded/collapsed state. */
+  cookieName?: string
 }>
 
-export const init = ({ id, defaultOpen = true }: InitConfig): Model => ({
-  isOpen: defaultOpen,
+export const init = ({
+  id,
+  defaultOpen = true,
+  cookieName = SIDEBAR_COOKIE_NAME,
+}: InitConfig): Model => ({
+  cookieName,
+  isOpen: readOpenCookie(cookieName) ?? defaultOpen,
   isMobile: false,
   sheet: Sheet.init({ id: `${id}-mobile-sheet` }),
 })
@@ -158,60 +162,133 @@ export const update = (model: Model, message: Message): Update.Return<Model, Mes
     }),
   )
 
+function readOpenCookie(cookieName: string): boolean | undefined {
+  if (typeof document === 'undefined') {
+    return undefined
+  }
+
+  const prefix = `${encodeURIComponent(cookieName)}=`
+  const value = document.cookie
+    .split(';')
+    .map((cookie) => cookie.trim())
+    .find((cookie) => cookie.startsWith(prefix))
+    ?.slice(prefix.length)
+
+  return value === 'true' ? true : value === 'false' ? false : undefined
+}
+
+const writeOpenCookie = (cookieName: string, isOpen: boolean): void => {
+  if (typeof document !== 'undefined') {
+    document.cookie = `${encodeURIComponent(cookieName)}=${isOpen}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+  }
+}
+
+const hydrateOpenState = (cookieName: string, isOpen: boolean): void => {
+  if (typeof document === 'undefined') {
+    return
+  }
+
+  const escapedCookieName = CSS.escape(cookieName)
+  for (const wrapper of document.querySelectorAll<HTMLElement>(
+    `[data-slot="sidebar-wrapper"][data-sidebar-cookie="${escapedCookieName}"]`,
+  )) {
+    const sidebar = wrapper.querySelector<HTMLElement>('[data-slot="sidebar"]:not([data-mobile])')
+    if (!sidebar) {
+      continue
+    }
+
+    sidebar.dataset.state = isOpen ? 'expanded' : 'collapsed'
+    sidebar.dataset.collapsible = isOpen ? '' : (sidebar.dataset.sidebarCollapsible ?? '')
+  }
+}
+
 /** Global listeners for an embedded sidebar: the upstream ⌘/Ctrl+B shortcut
  *  (always listening, like upstream's window keydown effect) and a media-query
  *  listener that keeps `isMobile` in sync with the viewport. Lift with
  *  `Subscription.lift(Sidebar.subscriptions)` from your slice. */
-export const subscriptions = Subscription.make<Model, Message>()((entry) => ({
-  keyboardShortcut: entry(
-    { isListening: S.Boolean },
-    {
-      modelToDependencies: () => ({ isListening: true }),
-      dependenciesToStream: ({ isListening }) =>
-        Stream.when(
-          Subscription.fromEventFilterMap<KeyboardEvent, Message>({
-            target: window,
-            type: 'keydown',
-            toMessage: (event) => {
-              if (event.key === SIDEBAR_KEYBOARD_SHORTCUT && (event.metaKey || event.ctrlKey)) {
-                event.preventDefault()
-                return Option.some(Message.Toggled())
-              }
-              return Option.none()
-            },
-          }),
-          Effect.sync(() => isListening),
-        ),
-    },
-  ),
-  mediaQuery: entry(
-    { isListening: S.Boolean },
-    {
-      modelToDependencies: () => ({ isListening: true }),
-      dependenciesToStream: ({ isListening }) =>
-        Stream.when(
+export const subscriptions = Subscription.make<Model, Message>()((entry) => {
+  let cookieHydrated = false
+
+  return {
+    cookie: entry(
+      { cookieName: S.String, isOpen: S.Boolean },
+      {
+        modelToDependencies: (model) => ({
+          cookieName: model.cookieName,
+          isOpen: model.isOpen,
+        }),
+        dependenciesToStream: ({ cookieName, isOpen }) =>
           Stream.callback<Message>((queue) =>
-            Effect.acquireRelease(
-              Effect.sync(() => {
-                const mediaQuery = window.matchMedia(MOBILE_MEDIA_QUERY)
-                const handler = (event: MediaQueryListEvent) => {
-                  Queue.offerUnsafe(queue, Message.SetIsMobile({ isMobile: event.matches }))
+            Effect.sync(() => {
+              const stored = readOpenCookie(cookieName)
+              if (!cookieHydrated) {
+                cookieHydrated = true
+                if (stored !== undefined && stored !== isOpen) {
+                  hydrateOpenState(cookieName, stored)
+                  Queue.offerUnsafe(queue, Message.SetIsOpen({ isOpen: stored }))
+                } else {
+                  writeOpenCookie(cookieName, isOpen)
                 }
-                mediaQuery.addEventListener('change', handler)
-                // Emit once on subscribe so a mobile viewport corrects the
-                // desktop default right after mount.
-                Queue.offerUnsafe(queue, Message.SetIsMobile({ isMobile: mediaQuery.matches }))
-                return { mediaQuery, handler }
-              }),
-              ({ mediaQuery, handler }) =>
-                Effect.sync(() => mediaQuery.removeEventListener('change', handler)),
-            ).pipe(Effect.flatMap(() => Effect.never)),
+              } else {
+                writeOpenCookie(cookieName, isOpen)
+              }
+            }).pipe(Effect.flatMap(() => Effect.never)),
           ),
-          Effect.sync(() => isListening),
-        ),
-    },
-  ),
-}))
+      },
+    ),
+    keyboardShortcut: entry(
+      { isListening: S.Boolean },
+      {
+        modelToDependencies: () => ({ isListening: true }),
+        dependenciesToStream: ({ isListening }) =>
+          Stream.when(
+            Subscription.fromEventFilterMap<KeyboardEvent, Message>({
+              target: window,
+              type: 'keydown',
+              toMessage: (event) => {
+                if (
+                  event.key.toLowerCase() === SIDEBAR_KEYBOARD_SHORTCUT &&
+                  (event.metaKey || event.ctrlKey)
+                ) {
+                  event.preventDefault()
+                  return Option.some(Message.Toggled())
+                }
+                return Option.none()
+              },
+            }),
+            Effect.sync(() => isListening),
+          ),
+      },
+    ),
+    mediaQuery: entry(
+      { isListening: S.Boolean },
+      {
+        modelToDependencies: () => ({ isListening: true }),
+        dependenciesToStream: ({ isListening }) =>
+          Stream.when(
+            Stream.callback<Message>((queue) =>
+              Effect.acquireRelease(
+                Effect.sync(() => {
+                  const mediaQuery = window.matchMedia(MOBILE_MEDIA_QUERY)
+                  const handler = (event: MediaQueryListEvent) => {
+                    Queue.offerUnsafe(queue, Message.SetIsMobile({ isMobile: event.matches }))
+                  }
+                  mediaQuery.addEventListener('change', handler)
+                  // Emit once on subscribe so a mobile viewport corrects the
+                  // desktop default right after mount.
+                  Queue.offerUnsafe(queue, Message.SetIsMobile({ isMobile: mediaQuery.matches }))
+                  return { mediaQuery, handler }
+                }),
+                ({ mediaQuery, handler }) =>
+                  Effect.sync(() => mediaQuery.removeEventListener('change', handler)),
+              ).pipe(Effect.flatMap(() => Effect.never)),
+            ),
+            Effect.sync(() => isListening),
+          ),
+      },
+    ),
+  }
+})
 
 export const sidebarProviderClass =
   'group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar'
@@ -388,6 +465,7 @@ export const view = defineView<Model, Message, ProviderViewInputs>((model, viewI
       [
         h.Class(cn(sidebarProviderClass, viewInputs.className)),
         h.DataAttribute('slot', 'sidebar-wrapper'),
+        h.DataAttribute('sidebar-cookie', model.cookieName),
         h.Style({ '--sidebar-width': SIDEBAR_WIDTH, '--sidebar-width-icon': SIDEBAR_WIDTH_ICON }),
       ],
       [
@@ -475,6 +553,7 @@ export const view = defineView<Model, Message, ProviderViewInputs>((model, viewI
       [
         h.Class(cn(sidebarProviderClass, viewInputs.className)),
         h.DataAttribute('slot', 'sidebar-wrapper'),
+        h.DataAttribute('sidebar-cookie', model.cookieName),
         h.Style({ '--sidebar-width': SIDEBAR_WIDTH, '--sidebar-width-icon': SIDEBAR_WIDTH_ICON }),
       ],
       [
@@ -504,6 +583,7 @@ export const view = defineView<Model, Message, ProviderViewInputs>((model, viewI
           h.DataAttribute('sidebar', 'sidebar'),
           h.DataAttribute('state', slots.state),
           h.DataAttribute('collapsible', slots.state === 'collapsed' ? collapsible : ''),
+          h.DataAttribute('sidebar-collapsible', collapsible),
           h.DataAttribute('variant', variant),
           h.DataAttribute('side', side),
         ],

--- a/packages/web/src/catalog/gaps.ts
+++ b/packages/web/src/catalog/gaps.ts
@@ -20,7 +20,6 @@ export const gapsByItem: Readonly<Record<string, ReadonlyArray<string>>> = {
     'Opens on activation at a fixed anchor — foldkit has no right-click/pointer-position anchoring primitive yet.',
   ],
   sidebar: [
-    'No cookie persistence — foldkit owns initial render through its own hydration rather than document.cookie (an SSR flash-prevention mechanism).',
     'Collapsed-mode menu-button tooltips are not auto-composed — wrap menu buttons in Tooltip submodels yourself if you need them.',
   ],
   toast: [

--- a/packages/web/src/demo/subscriptions.ts
+++ b/packages/web/src/demo/subscriptions.ts
@@ -2,11 +2,13 @@ import { Subscription } from 'foldkit'
 
 import type { Model, Message } from './assemble'
 import { subscriptions as dragAndDropSubscriptions } from './views/drag-and-drop'
+import { subscriptions as sidebarSubscriptions } from './views/sidebar'
 import { subscriptions as sliderSubscriptions } from './views/slider'
 import { subscriptions as virtualListSubscriptions } from './views/virtual-list'
 
 export const subscriptions = Subscription.aggregate<Model, Message>()(
   dragAndDropSubscriptions,
+  sidebarSubscriptions,
   sliderSubscriptions,
   virtualListSubscriptions,
 )

--- a/packages/web/src/demo/views/sidebar.ts
+++ b/packages/web/src/demo/views/sidebar.ts
@@ -70,7 +70,7 @@ export const sidebarView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
               // so the shell is contained by the transformed preview box.
               className:
                 '!min-h-0 !h-full [&_[data-slot=sidebar]]:!h-full [&_[data-slot=sidebar-container]]:!h-full',
-              content: (slots) => [
+              content: () => [
                 Sidebar.header({}, [teamSwitcher(h)], h),
                 Sidebar.content({}, [navMain(h), navProjects(h), secondarySupportGroup(h)], h),
                 Sidebar.footer({}, [navUser(h)], h),

--- a/packages/web/src/demo/views/sidebar.ts
+++ b/packages/web/src/demo/views/sidebar.ts
@@ -48,7 +48,7 @@ export const sidebarView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
         [
           'Collapsible app shell — toggle with the header button, the rail hot-spot, or ',
           h.kbd([h.Class('rounded border bg-muted px-1 font-mono text-[11px]')], ['⌘B']),
-          '. Resize below the md breakpoint for the mobile sheet.',
+          '. Collapse it, reload the page, and the demo restores the saved state from its cookie. Resize below the md breakpoint for the mobile sheet.',
         ],
       ),
       h.div(
@@ -74,7 +74,11 @@ export const sidebarView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
                 Sidebar.header({}, [teamSwitcher(h)], h),
                 Sidebar.content({}, [navMain(h), navProjects(h), secondarySupportGroup(h)], h),
                 Sidebar.footer({}, [navUser(h)], h),
-                Sidebar.rail(slots.rail, {}, h),
+                Sidebar.rail(
+                  [h.OnClick(Message.GotSidebarMessage({ message: Sidebar.Message.Toggled() }))],
+                  {},
+                  h,
+                ),
               ],
               children: (slots) => [
                 Sidebar.SidebarInset(
@@ -90,7 +94,15 @@ export const sidebarView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
                         h.div(
                           [h.Class('flex items-center gap-2 px-4')],
                           [
-                            Sidebar.trigger(slots.trigger, {}, h),
+                            Sidebar.trigger(
+                              [
+                                h.OnClick(
+                                  Message.GotSidebarMessage({ message: Sidebar.Message.Toggled() }),
+                                ),
+                              ],
+                              {},
+                              h,
+                            ),
                             Sidebar.separator({ className: '-ml-px mr-2 h-4' }, h),
                             h.span(
                               [h.Class('text-sm font-medium')],
@@ -352,7 +364,7 @@ const navUser = (h: HtmlBuilder<AppMessage>): Html =>
               h.span(
                 [
                   h.Class(
-                    'flex size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground text-xs font-semibold',
+                    'flex size-8 shrink-0 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground text-xs font-semibold',
                   ),
                 ],
                 ['CN'],
@@ -386,20 +398,28 @@ const foldSidebar = Update.foldChild({
   toParentMessage: (message) => Message.GotSidebarMessage({ message }),
 })
 
+export const subscriptions = Subscription.lift(Sidebar.subscriptions)<
+  State,
+  typeof Message.GotSidebarMessage.Type
+>({
+  toChildModel: (model) => model.sidebar,
+  toParentMessage: (message) => Message.GotSidebarMessage({ message }),
+})
+
 export const slice = defineSlice({
   fields,
-  init: { sidebar: Sidebar.init({ id: 'sidebar-demo', defaultOpen: true }) },
+  init: {
+    sidebar: Sidebar.init({
+      id: 'sidebar-demo',
+      defaultOpen: true,
+      cookieName: 'foldcn-sidebar-demo',
+    }),
+  },
   messages: [Message.GotSidebarMessage],
   handlers: (model: State) => ({
     GotSidebarMessage: (payload: typeof Message.GotSidebarMessage.Type): UpdateReturn =>
       foldSidebar(model, payload.message),
   }),
   samples: [Message.GotSidebarMessage({ message: Sidebar.Message.Toggled() })],
-  subscriptions: Subscription.lift(Sidebar.subscriptions)<
-    State,
-    typeof Message.GotSidebarMessage.Type
-  >({
-    toChildModel: (model) => model.sidebar,
-    toParentMessage: (message) => Message.GotSidebarMessage({ message }),
-  }),
+  subscriptions,
 })


### PR DESCRIPTION
## Summary

- Persist sidebar expanded/collapsed state in a 7-day cookie.
- Restore the saved state in the sidebar demo and document the reload behavior.
- Wire the demo sidebar subscriptions and prevent the Cmd/Ctrl+B browser default action.
- Keep the collapsed footer avatar from shrinking.

## Validation

- `pnpm fmt`
- `pnpm typecheck`
- `pnpm test` (11 tests passed)
- `pnpm validate`
- `git diff --check`
- Live sidebar demo checked at `/docs/sidebar`.

## Notes

The sidebar source includes formatting normalization around the subscription block as part of the required repository formatting pass. I’m happy to incorporate any feedback or requested adjustments from the maintainer.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist sidebar open/closed state in a cookie
> - Adds `readOpenCookie`, `writeOpenCookie`, and `hydrateOpenState` helpers to [sidebar.ts](https://github.com/elianiva/foldcn/pull/35/files#diff-504a0563bc61bd2858c7f4f7d270c4620b610b55e87cef950078b355f53ff819) so the sidebar restores its state on reload from a named cookie (default `sidebar_state`, max-age one week)
> - Reworks the `subscriptions` factory to add a cookie subscription that hydrates DOM on first load and writes the cookie on subsequent changes; also makes the keyboard shortcut case-insensitive
> - Updates the view provider wrapper and sidebar element with `data-sidebar-cookie` and `data-sidebar-collapsible` attributes to support DOM-side hydration before model-driven updates
> - Wires the demo sidebar to use a custom cookie name `foldcn-sidebar-demo` and fixes avatar shrinking with a `shrink-0` class
> - Risk: `Model` state schema gains a required `cookieName` field; any code constructing the model outside of `init` must set it or will fail
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 41eef93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->