### PR TITLE
Fix tooltip preview alignment and button styling

### DIFF
--- a/packages/registry/registry/default/ui/tooltip.ts
+++ b/packages/registry/registry/default/ui/tooltip.ts
@@ -50,8 +50,7 @@ export const TOOLTIP_ANCHOR: AnchorConfig = {
   gap: 4,
 }
 
-export const tooltipTriggerClass =
-  'inline-flex items-center justify-center rounded-md text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50'
+export const tooltipTriggerClass = 'cn-button cn-button-variant-outline cn-button-size-default'
 
 /**
  * The foldkit anchor writes the resolved side to `data-placement`; this view

--- a/packages/web/src/demo/views/tooltip.ts
+++ b/packages/web/src/demo/views/tooltip.ts
@@ -12,14 +12,18 @@ import type { Model, Message as AppMessage } from '../assemble'
 
 const Message = defineMessageUnion({
   GotTooltipMessage: { message: tooltip.Message },
+  GotTopTooltipMessage: { message: tooltip.Message },
+  GotRightTooltipMessage: { message: tooltip.Message },
+  GotBottomTooltipMessage: { message: tooltip.Message },
+  GotLeftTooltipMessage: { message: tooltip.Message },
 })
 
 export const tooltipView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
   h.div(
-    [h.Class('flex w-full flex-col gap-8')],
+    [h.Class('flex w-full flex-col items-center gap-8')],
     [
       h.div(
-        [h.Class('flex w-full flex-col gap-2')],
+        [h.Class('flex w-full flex-col items-center gap-2')],
         [
           h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], ['Basic']),
           h.submodel({
@@ -39,16 +43,64 @@ export const tooltipView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
         ],
       ),
       h.div(
-        [h.Class('flex w-full flex-col gap-2')],
+        [h.Class('flex w-full flex-col items-center gap-2')],
         [
           h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], ['Sides']),
           h.div(
             [h.Class('flex flex-wrap gap-2 justify-center')],
             [
-              h.span([h.Class('rounded-lg border px-3 py-1 text-sm')], ['Top']),
-              h.span([h.Class('rounded-lg border px-3 py-1 text-sm')], ['Right']),
-              h.span([h.Class('rounded-lg border px-3 py-1 text-sm')], ['Bottom']),
-              h.span([h.Class('rounded-lg border px-3 py-1 text-sm')], ['Left']),
+              h.submodel({
+                slotId: model.topTooltip.id,
+                model: model.topTooltip,
+                view: tooltip.view,
+                viewInputs: tooltip.styledViewInputs(
+                  { anchor: { placement: 'top', gap: 4 }, trigger: 'Top', content: 'Top tooltip' },
+                  h,
+                ),
+                toParentMessage: (message) => Message.GotTopTooltipMessage({ message }),
+              }),
+              h.submodel({
+                slotId: model.rightTooltip.id,
+                model: model.rightTooltip,
+                view: tooltip.view,
+                viewInputs: tooltip.styledViewInputs(
+                  {
+                    anchor: { placement: 'right', gap: 4 },
+                    trigger: 'Right',
+                    content: 'Right tooltip',
+                  },
+                  h,
+                ),
+                toParentMessage: (message) => Message.GotRightTooltipMessage({ message }),
+              }),
+              h.submodel({
+                slotId: model.bottomTooltip.id,
+                model: model.bottomTooltip,
+                view: tooltip.view,
+                viewInputs: tooltip.styledViewInputs(
+                  {
+                    anchor: { placement: 'bottom', gap: 4 },
+                    trigger: 'Bottom',
+                    content: 'Bottom tooltip',
+                  },
+                  h,
+                ),
+                toParentMessage: (message) => Message.GotBottomTooltipMessage({ message }),
+              }),
+              h.submodel({
+                slotId: model.leftTooltip.id,
+                model: model.leftTooltip,
+                view: tooltip.view,
+                viewInputs: tooltip.styledViewInputs(
+                  {
+                    anchor: { placement: 'left', gap: 4 },
+                    trigger: 'Left',
+                    content: 'Left tooltip',
+                  },
+                  h,
+                ),
+                toParentMessage: (message) => Message.GotLeftTooltipMessage({ message }),
+              }),
             ],
           ),
         ],
@@ -77,18 +129,76 @@ const foldTooltip = Update.foldChild({
   foldOutMessage: foldTooltipOutMessage,
 })
 
-const fields = { tooltip: tooltip.Model }
+const foldTopTooltip = Update.foldChild({
+  update: tooltip.update,
+  read: (model: State) => Option.some(model.topTooltip),
+  write: (model, next) => evo(model, { topTooltip: () => next }),
+  toParentMessage: (message) => Message.GotTopTooltipMessage({ message }),
+  foldOutMessage: foldTooltipOutMessage,
+})
+
+const foldRightTooltip = Update.foldChild({
+  update: tooltip.update,
+  read: (model: State) => Option.some(model.rightTooltip),
+  write: (model, next) => evo(model, { rightTooltip: () => next }),
+  toParentMessage: (message) => Message.GotRightTooltipMessage({ message }),
+  foldOutMessage: foldTooltipOutMessage,
+})
+
+const foldBottomTooltip = Update.foldChild({
+  update: tooltip.update,
+  read: (model: State) => Option.some(model.bottomTooltip),
+  write: (model, next) => evo(model, { bottomTooltip: () => next }),
+  toParentMessage: (message) => Message.GotBottomTooltipMessage({ message }),
+  foldOutMessage: foldTooltipOutMessage,
+})
+
+const foldLeftTooltip = Update.foldChild({
+  update: tooltip.update,
+  read: (model: State) => Option.some(model.leftTooltip),
+  write: (model, next) => evo(model, { leftTooltip: () => next }),
+  toParentMessage: (message) => Message.GotLeftTooltipMessage({ message }),
+  foldOutMessage: foldTooltipOutMessage,
+})
+
+const fields = {
+  tooltip: tooltip.Model,
+  topTooltip: tooltip.Model,
+  rightTooltip: tooltip.Model,
+  bottomTooltip: tooltip.Model,
+  leftTooltip: tooltip.Model,
+}
 
 const stateSchema = S.Struct(fields)
 type State = typeof stateSchema.Type
 
 export const slice = defineSlice({
   fields,
-  init: { tooltip: tooltip.init({ id: 'tooltip-demo' }) },
-  messages: [Message.GotTooltipMessage],
+  init: {
+    tooltip: tooltip.init({ id: 'tooltip-demo' }),
+    topTooltip: tooltip.init({ id: 'tooltip-top-demo' }),
+    rightTooltip: tooltip.init({ id: 'tooltip-right-demo' }),
+    bottomTooltip: tooltip.init({ id: 'tooltip-bottom-demo' }),
+    leftTooltip: tooltip.init({ id: 'tooltip-left-demo' }),
+  },
+  messages: [
+    Message.GotTooltipMessage,
+    Message.GotTopTooltipMessage,
+    Message.GotRightTooltipMessage,
+    Message.GotBottomTooltipMessage,
+    Message.GotLeftTooltipMessage,
+  ],
   handlers: (model: State) => ({
     GotTooltipMessage: (payload: typeof Message.GotTooltipMessage.Type): UpdateReturn =>
       foldTooltip(model, payload.message),
+    GotTopTooltipMessage: (payload: typeof Message.GotTopTooltipMessage.Type): UpdateReturn =>
+      foldTopTooltip(model, payload.message),
+    GotRightTooltipMessage: (payload: typeof Message.GotRightTooltipMessage.Type): UpdateReturn =>
+      foldRightTooltip(model, payload.message),
+    GotBottomTooltipMessage: (payload: typeof Message.GotBottomTooltipMessage.Type): UpdateReturn =>
+      foldBottomTooltip(model, payload.message),
+    GotLeftTooltipMessage: (payload: typeof Message.GotLeftTooltipMessage.Type): UpdateReturn =>
+      foldLeftTooltip(model, payload.message),
   }),
   samples: [],
   // Tooltip show/hide flows entirely through the submodel; the public


### PR DESCRIPTION
## What changed

- Center the Tooltip preview content.
- Replace static direction labels with working top, right, bottom, and left Tooltip examples.
- Route each Tooltip submodel through its own state field and parent message.
- Use the Button component outline variant for Tooltip triggers.

## Verification

- `pnpm fmt`
- `pnpm --filter @foldcn/registry run build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm validate`
- `pnpm lint`
- `git diff --check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix tooltip trigger styling and expand demo with directional tooltip examples
> - Replaces inline utility classes in `tooltipTriggerClass` with the shared outline/default button class composition in [tooltip.ts](https://github.com/elianiva/foldcn/pull/38/files#diff-6a937620e2843dbcd5e7462564bb49c224b47cebe0c16d0d663bacbf539877d7)
> - Overhauls the tooltip demo in [tooltip.ts](https://github.com/elianiva/foldcn/pull/38/files#diff-f74804bab195fea24363c7a42a379909815be188bf31df6cbe26721f7614de19) to render interactive tooltip controls for top, right, bottom, and left placements instead of static text labels
> - Adds four directional tooltip submodels to the demo state, each with its own message variant and child-update fold that routes events to the matching model
> - Behavioral Change: tooltip triggers now use the shared button outline/default styling; the demo state schema gains four new directional model fields
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c8f72b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->