### PR TITLE
fix(web): compose breadcrumb dropdown with Menu

### DIFF
--- a/packages/web/src/demo/assemble.ts
+++ b/packages/web/src/demo/assemble.ts
@@ -294,6 +294,7 @@ export const update = (model: Model, message: Message): DemoUpdateReturn => {
     M.tagsExhaustive({
       ...accordionSlice.handlers(model),
       ...alertDialogSlice.handlers(model),
+      ...breadcrumbSlice.handlers(model),
       ...animationSlice.handlers(model),
       ...avatarSlice.handlers(model),
       ...buttonSlice.handlers(model),

--- a/packages/web/src/demo/views/breadcrumb.ts
+++ b/packages/web/src/demo/views/breadcrumb.ts
@@ -1,11 +1,24 @@
+import { Update } from 'foldkit'
+import { Match as M, Option } from 'effect'
+import { Schema as S } from 'effect'
+import { evo } from 'foldkit/struct'
+import { defineMessageUnion } from 'foldkit/message'
 import type { Html, HtmlBuilder } from 'foldkit/html'
 
+import { Menu as FoldkitMenu } from '@foldkit/ui'
+
 import { Breadcrumb } from '../../generated/registry/ui/breadcrumb'
+import * as menu from '../../generated/registry/ui/menu'
 
-import { defineSlice } from '../slice'
-import type { Model, Message } from '../assemble'
+import { DemoMenu } from '../bundles'
+import { defineSlice, type UpdateReturn } from '../slice'
+import type { Model, Message as AppMessage } from '../assemble'
 
-export const breadcrumbView = (_model: Model, h: HtmlBuilder<Message>): Html =>
+export const Message = defineMessageUnion({
+  GotBreadcrumbMenuMessage: { message: menu.Message },
+})
+
+export const breadcrumbView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
   h.div(
     [h.Class('flex w-full flex-col gap-8')],
     [
@@ -44,7 +57,31 @@ export const breadcrumbView = (_model: Model, h: HtmlBuilder<Message>): Html =>
                 [
                   Breadcrumb.item({}, [Breadcrumb.link({}, ['Home'], h)], h),
                   Breadcrumb.separator({}, [], h),
-                  Breadcrumb.ellipsis({}, [], h),
+                  Breadcrumb.item(
+                    {},
+                    [
+                      h.submodel({
+                        slotId: model.breadcrumbMenu.id,
+                        model: model.breadcrumbMenu,
+                        view: DemoMenu.view,
+                        viewInputs: menu.viewInputs<string>({
+                          items: ['Documentation', 'Themes', 'GitHub'],
+                          buttonContent: h.span(
+                            [],
+                            [
+                              Breadcrumb.ellipsis({}, [], h),
+                              h.span([h.Class('sr-only')], ['Toggle menu']),
+                            ],
+                          ),
+                          itemToConfig: (item) => ({
+                            content: h.span([], [item]),
+                          }),
+                        }),
+                        toParentMessage: (message) => Message.GotBreadcrumbMenuMessage({ message }),
+                      }),
+                    ],
+                    h,
+                  ),
                   Breadcrumb.separator({}, [], h),
                   Breadcrumb.item({}, [Breadcrumb.link({}, ['Components'], h)], h),
                   Breadcrumb.separator({}, [], h),
@@ -85,9 +122,39 @@ export const breadcrumbView = (_model: Model, h: HtmlBuilder<Message>): Html =>
     ],
   )
 
+const foldNoOp =
+  <Out>(): ((out: Out) => Update.Step<State, unknown>) =>
+  () =>
+  (model) => ({ model })
+
+const foldBreadcrumbMenuOutMessage = M.type<FoldkitMenu.OutMessage>().pipe(
+  M.withReturnType<Update.Step<State, unknown>>(),
+  M.tagsExhaustive({
+    Selected: foldNoOp(),
+  }),
+)
+
+const foldBreadcrumbMenu = Update.foldChild({
+  update: DemoMenu.update,
+  read: (model: State) => Option.some(model.breadcrumbMenu),
+  write: (model, next) => evo(model, { breadcrumbMenu: () => next }),
+  toParentMessage: (message) => Message.GotBreadcrumbMenuMessage({ message }),
+  foldOutMessage: foldBreadcrumbMenuOutMessage,
+})
+
+const fields = { breadcrumbMenu: menu.Model }
+
+const stateSchema = S.Struct(fields)
+type State = typeof stateSchema.Type
+
 export const slice = defineSlice({
-  fields: {},
-  init: {},
-  messages: [],
-  handlers: () => ({}),
+  fields,
+  init: { breadcrumbMenu: menu.init({ id: 'breadcrumb-dropdown' }) },
+  messages: [Message.GotBreadcrumbMenuMessage],
+  handlers: (model: State) => ({
+    GotBreadcrumbMenuMessage: (
+      payload: typeof Message.GotBreadcrumbMenuMessage.Type,
+    ): UpdateReturn => foldBreadcrumbMenu(model, payload.message),
+  }),
+  samples: [],
 })


### PR DESCRIPTION
Composes the With Dropdown breadcrumb with the dropdown primitive.

Reference: apps/v4/registry/bases/base/examples/breadcrumb-example.tsx BreadcrumbWithDropdown

- Home > Dropdown(ellipsis+Toggle menu: Documentation, Themes, GitHub) > Components > Breadcrumb
- Uses DemoMenu (Menu.create<string>()) with id breadcrumb-dropdown
- Menu state via defineSlice: Model, GotBreadcrumbMenuMessage, foldChild to DemoMenu.update, outMessage Selected noop
- Wires breadcrumbSlice.handlers into assemble.ts update dispatcher
- Preserves With Link (static ellipsis) unchanged

Verification:
- pnpm --filter @foldcn/web run typecheck passes
- pnpm --filter @foldcn/registry run build + pnpm --filter @foldcn/web run build passes
- Prerendered docs/breadcrumb contains Toggle menu, Documentation, Themes, GitHub

Fixes breadcrumb dropdown that rendered a static ellipsis instead of an interactive Menu.