### PR TITLE
chore: setup lefthook for lint, build and formatting githooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,17 @@
+pre-commit:
+  # fmt must run before lint so fixes are staged before lint checks
+  parallel: false
+  commands:
+    fmt:
+      run: pnpm fmt
+      stage_fixed: true
+    lint:
+      run: pnpm lint
+
+pre-push:
+  parallel: true
+  commands:
+    build:
+      run: pnpm build
+    typecheck:
+      run: pnpm typecheck

--- a/package.json
+++ b/package.json
@@ -13,13 +13,15 @@
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
     "validate": "turbo run validate",
-    "infra:deploy": "alchemy deploy --stage prod --yes"
+    "infra:deploy": "alchemy deploy --stage prod --yes",
+    "prepare": "lefthook install"
   },
   "devDependencies": {
     "@effect/platform-node": "4.0.0-rc.112",
     "@oxlint/plugins": "1.77.0",
     "alchemy": "2.0.0-beta.75",
     "effect": "4.0.0-rc.112",
+    "lefthook": "^2.1.12",
     "oxlint": "1.77.0",
     "turbo": "^2.10.12",
     "typescript": "^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       effect:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
+      lefthook:
+        specifier: ^2.1.12
+        version: 2.1.12
       oxlint:
         specifier: 1.77.0
         version: 1.77.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.3.0(@types/node@26.4.0)(esbuild@0.28.2)(happy-dom@20.12.0)(jiti@2.7.0)(tsx@4.23.13)(typescript@7.0.2)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))(yaml@2.9.0))
@@ -2643,6 +2646,60 @@ packages:
 
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
+  lefthook-darwin-arm64@2.1.12:
+    resolution: {integrity: sha512-GSUjqaCuxAYlPOovbjXEWE3HAIa/xOQkTTmZ937zieQldjPLTaC7+s5FHoxKywn+D9riBlofkDqG7Z4f5zzmPA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.12:
+    resolution: {integrity: sha512-qAUHSSw/7Afi5wxkoLkxORxSicCeTBXyVLnRgD6YZra6udviozpK3Aok9Z6FIWeKc5FBijRMSNDxGPTREhsjcQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.12:
+    resolution: {integrity: sha512-FHZRfKliFNbyz54zsoGdVe9muq67cNjBTZ6jrPPUjI7xUuyCwSpzA+1OpiwJT00L9pP5ZGONBqnGZKnrpC+7Uw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.12:
+    resolution: {integrity: sha512-HYQZPGy2DDEx7dbuotusJpujY5q9igOLgx36qeeQcNQuvvdGHPj2ZGSIsGKhoJ0dw5Qa4knKJoPAHEZQWdV/og==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.12:
+    resolution: {integrity: sha512-ipjOri2PB/sk4noPrHQuM5fcpNBjmlKo4qMtXyLnxeOxGYHWZzf0Xi0OtrXHQ//tOprcv40ADvhUuSdcGqigLw==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.12:
+    resolution: {integrity: sha512-DmU6xfvqVoFdW+STyc70YI4Ry8vkHGKHx+IJ1Js/Gacq5dv+fiwNzwle3bi28EkL6P8xY67B/CfQfRj4SRU4tg==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.12:
+    resolution: {integrity: sha512-vb0J7bElLvoaCWQmna3HntsvoNqMsGAhfjjC99ss1OdCteufZKM3RxCVoMBEbD50Itv2c1Ua2AFVToltVFTy1Q==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.12:
+    resolution: {integrity: sha512-QOmhDWqPPK4+99scanfEmbJjUR+JYC93qhr/0bp5Dj3LaR3kVFNWc6zOQUsOTPy/LC6PG759Lej/mr/BtjUL2Q==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.12:
+    resolution: {integrity: sha512-eErEyr9AHkRFj6TxpCQeKGd0s6IrtL/VEIZ/ssg8dNfG+ycR4jAW/IAlrJSw6/ZQXb3WtWLaQ6QA5c+TLh7vmg==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.12:
+    resolution: {integrity: sha512-0h+WmDVdDriTjloD/UbjPq/ZtqaaJlPAdGcVwMCEdAxfbF0FTgDbKX3igui9g2U/qG2y6QpVhtz1jeiRe7ctaw==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.12:
+    resolution: {integrity: sha512-2uOexfsrrRhCiTUWdGyDySxVHHhOFJ8MQejs27dM3hugrQB48/z1ZVlaNoxpZ1SnzQ1GaDIbO5rAvicwyiknYQ==}
+    hasBin: true
 
   libsodium-wrappers@0.8.4:
     resolution: {integrity: sha512-mu8aAWucZjTB5O/BtGXtW4e1agy7uHxNYG7zPthmmD1jU43LCDmSWZLN4JhflbdPXj3yDO4lxM1O9hLDgIOXDw==}
@@ -5449,6 +5506,49 @@ snapshots:
       pako: 1.0.11
       readable-stream: 2.3.8
       setimmediate: 1.0.5
+
+  lefthook-darwin-arm64@2.1.12:
+    optional: true
+
+  lefthook-darwin-x64@2.1.12:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.12:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.12:
+    optional: true
+
+  lefthook-linux-arm64@2.1.12:
+    optional: true
+
+  lefthook-linux-x64@2.1.12:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.12:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.12:
+    optional: true
+
+  lefthook-windows-arm64@2.1.12:
+    optional: true
+
+  lefthook-windows-x64@2.1.12:
+    optional: true
+
+  lefthook@2.1.12:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.12
+      lefthook-darwin-x64: 2.1.12
+      lefthook-freebsd-arm64: 2.1.12
+      lefthook-freebsd-x64: 2.1.12
+      lefthook-linux-arm64: 2.1.12
+      lefthook-linux-x64: 2.1.12
+      lefthook-openbsd-arm64: 2.1.12
+      lefthook-openbsd-x64: 2.1.12
+      lefthook-windows-arm64: 2.1.12
+      lefthook-windows-x64: 2.1.12
 
   libsodium-wrappers@0.8.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
 minimumReleaseAge: 0
 allowBuilds:
   esbuild: true
+  lefthook: true
   msgpackr-extract: true
   sharp: true
   workerd: true


### PR DESCRIPTION
## Summary

Configure [lefthook](https://lefthook.dev) as the git hook manager so lint, formatting, and build checks run automatically. Prevents unformatted, unlinted, or broken code from being committed or pushed.

Closes the request to setup `https://lefthook.dev` for githooks to run lint, build, and formatting.

## Motivation

- No git hooks existed (`lefthook.yml` missing, `package.json` had no `prepare`).
- CI runs `pnpm fmt -- --check`, `pnpm lint`, `pnpm typecheck`, `pnpm test` on every push, but local dev could push broken code.
- The vite-plus dispatcher (`.vite-hooks/_` via `core.hooksPath`) was enabled and would conflict with any other hook manager.

## Changes

| File | Change |
| --- | --- |
| `lefthook.yml` | New. `pre-commit` runs `pnpm fmt` (with `stage_fixed: true` to re-stage fixes) then `pnpm lint` sequentially. `pre-push` runs `pnpm build` and `pnpm typecheck` in parallel. |
| `package.json` | Adds `lefthook@^2.1.12` to `devDependencies` and `prepare: lefthook install` for auto-sync on `pnpm install`. |
| `pnpm-workspace.yaml` | Adds `lefthook: true` to `allowBuilds` so the postinstall script is permitted under pnpm 11. |
| `pnpm-lock.yaml` | Updated via `pnpm add -D lefthook`. |

### lefthook.yml

```yaml
pre-commit:
  parallel: false
  commands:
    fmt:
      run: pnpm fmt
      stage_fixed: true
    lint:
      run: pnpm lint

pre-push:
  parallel: true
  commands:
    build:
      run: pnpm build
    typecheck:
      run: pnpm typecheck
```

**Design choice:** split fast vs heavy. `fmt` + `lint` on commit stays fast (~15–20s). `build` + `typecheck` on push is heavier (~1m35s for typecheck, build cached) and does not block every commit. This covers all three requested checks (lint, build, formatting) across the two hooks.

**Conflict with vite-plus:** `vp hooks` was disabled (`git config vp.hooks.disabled true` and `core.hooksPath` unset) so lefthook owns `.git/hooks` directly. This is required for worktrees (hooks live in the common dir `/Users/elianiva/Development/personal/libraries/foldcn/.git/hooks`, not `.vite-hooks/_`). `pnpm install` no longer re-enables the vite-plus dispatcher.

## Verification

- `pnpm exec lefthook validate` → `All good`
- `pnpm exec lefthook dump` matches config
- `pnpm exec lefthook install` → `sync hooks: ✔️(pre-commit, pre-push)` (verbose log shows common dir resolution for worktree)
- `pnpm lint` → `vp lint` pass
- `pnpm fmt` → `Finished in 1428ms on 234 files`
- `pnpm build` → `Tasks: 2 successful`, generates 69 SSG pages
- **Live hook test on commit push:** creating the commit triggered `pre-commit` (fmt 5.5s + lint 14.1s, total 19.81s, both ✔️). Pushing triggered `pre-push` (build 2.52s cached + typecheck 98.32s, both ✔️). Hooks run for real, not just config.

## Usage

```bash
pnpm install        # prepare runs lefthook install automatically
git commit -m "..." # runs fmt + lint, re-stages formatted files
git push            # runs build + typecheck
```

Bypass when needed:

```bash
LEFTHOOK=0 git commit -m "..."
git commit --no-verify
LEFTHOOK=0 git push
```

Re-sync manually:

```bash
pnpm exec lefthook install
pnpm exec lefthook run pre-commit
pnpm exec lefthook run pre-push
```

## Notes

- Worktree-safe: hooks are installed to the common `.git/hooks`, shared by all worktrees for this repo.
- If you want build on every commit instead of just on push, add a `build` command to `pre-commit` (sequential). Kept on `pre-push` to preserve fast commits.
- `pnpm.onlyBuiltDependencies` in `package.json` was not added; pnpm 11 warns it is ignored and `allowBuilds` in `pnpm-workspace.yaml` is sufficient.