### PR TITLE
fix(toast): make variants work in demo and fix dismiss hit-area

### DIFF
--- a/packages/registry/registry/default/ui/toast.ts
+++ b/packages/registry/registry/default/ui/toast.ts
@@ -103,7 +103,7 @@ export const toastTitleClass = 'text-sm font-medium'
 export const toastDescriptionClass = 'text-sm text-muted-foreground'
 
 export const toastDismissButtonClass =
-  "shrink-0 cursor-pointer rounded-md p-1 text-muted-foreground opacity-70 transition-opacity hover:text-foreground hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0 after:absolute after:-inset-2 after:content-['']"
+  "relative shrink-0 cursor-pointer rounded-md p-1 text-muted-foreground opacity-70 transition-opacity hover:text-foreground hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0 after:absolute after:-inset-2 after:content-['']"
 
 export const toastActionClass = 'shrink-0'
 

--- a/packages/web/src/demo/views/toast.ts
+++ b/packages/web/src/demo/views/toast.ts
@@ -33,12 +33,7 @@ export const toastView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
             [
               h.div(
                 [h.Class('flex flex-wrap gap-2')],
-                [
-                  hButton(h, 'Info', Message.ClickedShowInfoToast()),
-                  hButton(h, 'Success', Message.ClickedShowSuccessToast()),
-                  hButton(h, 'Warning', Message.ClickedShowWarningToast()),
-                  hButton(h, 'Error', Message.ClickedShowErrorToast()),
-                ],
+                [hButton(h, 'Show toast', Message.ClickedShowInfoToast())],
               ),
               h.div(
                 [h.Class('flex flex-wrap gap-2')],
@@ -87,10 +82,10 @@ export const toastView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
           h.div(
             [h.Class('flex flex-wrap gap-2')],
             [
-              h.span([h.Class('rounded-lg border px-3 py-1 text-sm')], ['Info']),
-              h.span([h.Class('rounded-lg border px-3 py-1 text-sm bg-green-50')], ['Success']),
-              h.span([h.Class('rounded-lg border px-3 py-1 text-sm bg-yellow-50')], ['Warning']),
-              h.span([h.Class('rounded-lg border px-3 py-1 text-sm bg-red-50')], ['Error']),
+              hVariantButton(h, 'Info', Message.ClickedShowInfoToast()),
+              hVariantButton(h, 'Success', Message.ClickedShowSuccessToast()),
+              hVariantButton(h, 'Warning', Message.ClickedShowWarningToast()),
+              hVariantButton(h, 'Error', Message.ClickedShowErrorToast()),
             ],
           ),
         ],
@@ -105,6 +100,25 @@ const hButton = (h: HtmlBuilder<AppMessage>, label: string, message: AppMessage)
       h.OnClick(message),
     ],
     [label],
+  )
+
+/** Live variant button: renders the registry's own per-variant icon
+ *  (`ToastModule.toastIcon`, the same renderer the toast stack uses) and
+ *  fires a real toast of that variant on click — mirroring upstream's
+ *  `toast-types` demo. Previously this section was inert tinted spans. */
+const hVariantButton = (
+  h: HtmlBuilder<AppMessage>,
+  variant: 'Info' | 'Success' | 'Warning' | 'Error',
+  message: AppMessage,
+): Html =>
+  h.button(
+    [
+      h.Class(
+        'inline-flex items-center gap-2 rounded-md border border-input bg-background px-4 py-2 text-sm font-medium',
+      ),
+      h.OnClick(message),
+    ],
+    [ToastModule.toastIcon(h, variant), variant],
   )
 
 const foldNoOp =

--- a/packages/web/src/toast-variants.test.ts
+++ b/packages/web/src/toast-variants.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { Schema as S } from 'effect'
+
+import * as ToastModule from '@foldcn/registry/styles/default/ui/toast'
+
+// Regression guard: every toast variant must flow from `show()` into the
+// entry model (driving the per-variant icon, ARIA role, and `data-variant`
+// the styled view renders) and only `Error` carries the destructive icon
+// tint — matching upstream `toast.tsx` `ToastIcon`, where the error icon is
+// the sole colored one. Before this guard, the demo's Variants section was
+// inert tinted spans that never touched the variant API at all.
+
+const Toast = ToastModule.make(S.Struct({ title: S.String }))
+
+describe('toast variants', () => {
+  it.each(['Info', 'Success', 'Warning', 'Error'] as const)(
+    'show() stores variant %s on the entry',
+    (variant) => {
+      const model = Toast.init({ id: 'test-toast' })
+      const { model: next } = Toast.show(model, { variant, payload: { title: 't' } })
+      expect(next.toast.entries).toHaveLength(1)
+      expect(next.toast.entries[0]?.variant).toBe(variant)
+    },
+  )
+
+  it('show() without a variant defaults to Info', () => {
+    const model = Toast.init({ id: 'test-toast' })
+    const { model: next } = Toast.show(model, { payload: { title: 't' } })
+    expect(next.toast.entries[0]?.variant).toBe('Info')
+  })
+
+  it('only the Error variant tints its icon destructive', () => {
+    expect(ToastModule.toastVariantClass('Error')).toBe('text-destructive')
+    expect(ToastModule.toastVariantClass('Info')).toBe('')
+    expect(ToastModule.toastVariantClass('Success')).toBe('')
+    expect(ToastModule.toastVariantClass('Warning')).toBe('')
+  })
+
+  it('dismiss button is positioned to anchor its close hit-slop', () => {
+    // Upstream `ToastClose` is `relative ... after:-inset-2`; without
+    // `relative` the invisible hit area anchors to the entry card instead
+    // of the button.
+    expect(ToastModule.toastDismissButtonClass).toMatch(/(^|\s)relative(\s|$)/)
+  })
+})


### PR DESCRIPTION
## Problem
The Toast demo's **Variants** section rendered four inert tinted `<span>` pills (`bg-green-50` / `bg-yellow-50` / `bg-red-50` — hardcoded light-mode-only classes, not theme tokens). They fired nothing, so the toast variants did not work from the demo, unlike upstream's live `toast-types` example (Default/Success/Info/Warning/Error buttons).

## Root cause
- **Demo** (`packages/web/src/demo/views/toast.ts`): the Variants gallery never touched the component's variant API — dead spans instead of live toasts.
- **Source** (`packages/registry/registry/default/ui/toast.ts`): `toastDismissButtonClass` was missing upstream `ToastClose`'s `relative`, so the `after:-inset-2` close hit-slop anchored to the entry card instead of the close button.

Variant plumbing itself (icon per variant via `toastIcon`, `text-destructive` only on Error, ARIA role/status-alert + `data-variant` from the primitive) already matched upstream `toast.tsx` and was verified visually for all four variants — no change needed there.

## Changed files
- `packages/registry/registry/default/ui/toast.ts` — `toastDismissButtonClass` gains `relative` (upstream `ToastClose` parity).
- `packages/web/src/demo/views/toast.ts` — Basic section keeps a single Show toast + Dismiss all (mirrors upstream `toast-demo`); Variants section is now four live buttons rendering the registry's own `toastIcon` per variant and firing real toasts through `Toast.show` (mirrors upstream `toast-types`). No slice/message changes — existing `ClickedShow*Toast` messages reused.
- `packages/web/src/toast-variants.test.ts` — new: `show()` stores each variant on the entry, omitted variant defaults to Info, only Error tints destructive, dismiss button anchors its hit-slop.

## Test plan
- `pnpm --filter @foldcn/registry run build` — ships fix into `dist/r/toast.json`, no `cn-*` leaks in resolved output.
- `pnpm --filter @foldcn/web run typecheck` + `pnpm --filter @foldcn/registry run typecheck` — clean.
- `pnpm --filter @foldcn/web run test` — 3 files / 18 tests pass (7 new).
- `pnpm lint`, `pnpm fmt` — clean.
- `pnpm --filter @foldcn/web run build` (SSG) — prerenders; dead-pill classes gone from `/docs/toast`.
- Browser (dev server, agent-browser): fired Info/Success/Warning/Error from the new Variants buttons — correct per-variant icons, stack/peek choreography, manual close, Dismiss all, auto-dismiss; verified in default, vega, and sera + dark mode.

## Screenshots/notes
Visual: Variants row now shows icon buttons (info / check-circle / triangle / red octagon) that each raise the matching toast bottom-right. Dismiss/auto-dismiss/hover choreography unchanged (swipe-to-dismiss still awaits the @foldkit/ui gesture primitive — pre-existing documented gap).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix toast dismiss button hit-area and make demo variants interactive
> - Adds `relative` positioning to `toastDismissButtonClass` in [toast.ts](https://github.com/elianiva/foldcn/pull/45/files#diff-76b5c6ea0890e79fb737f1eb437b85da7cfa4653a43da02249c2c03e1db5107d) so the absolutely positioned pseudo-element hit-slop anchors to the button.
> - Replaces inert variant labels in the toast demo ([toast.ts](https://github.com/elianiva/foldcn/pull/45/files#diff-b11c1249ab9e241d1cc07bea4909eea69d9742890e1c910c9bfd7c6b8cda0f7e)) with clickable `hVariantButton` controls that render the variant icon and dispatch the corresponding toast message.
> - Adds regression tests in [toast-variants.test.ts](https://github.com/elianiva/foldcn/pull/45/files#diff-b6d67b67651c9cf80a9c6d2597ccd6029c2df14fc8953cfcca132426b91cb88f) covering variant storage, default-to-Info fallback, destructive icon on Error only, and dismiss-button positioning.
> - Risk: demo Basic section is reduced to a single informational toast control; existing demo flows that relied on multiple Basic variants are gone.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6d1f79.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->