### PR TITLE
fix(registry): no scrollbars on non-scrolling floating panels

### DIFF
--- a/packages/registry/registry/default/style/cn-compat.css
+++ b/packages/registry/registry/default/style/cn-compat.css
@@ -137,6 +137,45 @@
   @apply overflow-hidden!;
 }
 
+/* `--anchor-width` bridge: upstream sizes dropdown/select/combobox panels to
+ * the trigger (`w-(--anchor-width)`, combobox also
+ * `min-w-[calc(var(--anchor-width)+--spacing(7))]`), resolving the var through
+ * Base UI's positioner. Foldkit's anchor publishes the trigger width as
+ * `--button-width` on the panel instead, so those utilities are dead (panels
+ * fall back to auto/min-w — e.g. a 192px select trigger got a 144px panel).
+ * Alias the var on the consuming tokens (menubar inherits it through its
+ * dropdown composition). No foldkit equivalent exists for
+ * `--available-height`/`--available-width`/`--transform-origin`; the inline
+ * max-height cap and centered zoom origin stand in. */
+.cn-dropdown-menu-content,
+.cn-select-content,
+.cn-combobox-content {
+  @apply [--anchor-width:var(--button-width)];
+}
+
+/* Placement-keyed slide twins: foldkit writes the live side to
+ * `data-placement` (bare side, `-start`/`-end` stripped) on every anchored
+ * panel, but only popover/tooltip/navigation-menu emit (static) `data-side`
+ * — and `flip` can move the panel after render (observed: side=bottom with
+ * placement=top), so the vendored `data-[side=…]` slide-ins play from the
+ * wrong direction, or never play where no side is emitted at all. These twins
+ * apply the same slide when the live placement disagrees with the rendered
+ * side; the `:not()` guard raises specificity so the live side wins
+ * deterministically, and goes inert when they agree. All eight styles agree
+ * on the slide mapping. (Menubar inherits the dropdown twins through its
+ * composition. Tooltip arrow geometry stays `data-side`-keyed — the arrow is
+ * a child element and cannot see the panel's placement — so wrong-edge
+ * arrows post-flip remain a known gap.) */
+.cn-popover-content,
+.cn-tooltip-content,
+.cn-hover-card-content,
+.cn-dropdown-menu-content,
+.cn-select-content,
+.cn-context-menu-content,
+.cn-combobox-content {
+  @apply not-data-[side=bottom]:data-[placement=bottom]:slide-in-from-top-2 not-data-[side=left]:data-[placement=left]:slide-in-from-right-2 not-data-[side=right]:data-[placement=right]:slide-in-from-left-2 not-data-[side=top]:data-[placement=top]:slide-in-from-bottom-2;
+}
+
 /* sheet: upstream keys enter/exit motion on data-starting-style/
  * data-ending-style, which foldkit cannot emit — mapped to its
  * data-enter/data-leave transition windows instead. */

--- a/packages/registry/registry/default/style/cn-compat.css
+++ b/packages/registry/registry/default/style/cn-compat.css
@@ -110,6 +110,33 @@
   @apply data-enter:animate-in data-enter:fade-in-0 data-enter:zoom-in-95 data-leave:animate-out data-leave:fade-out-0 data-leave:zoom-out-95 duration-300;
 }
 
+/* Floating panels that never scroll upstream: foldkit's anchor `size`
+ * middleware unconditionally writes inline `max-height: <available>px` +
+ * `overflow-y: auto` onto every anchored panel without an arrow element (see
+ * @foldkit/ui anchor/anchor.js). Upstream popover/tooltip/hover-card/
+ * navigation-menu popups have no max-height and no overflow, and the tooltip
+ * arrow deliberately protrudes past the panel's padding box — so the forced
+ * scroll container puts a scrollbar on panels whose content merely fits
+ * (tooltip, every side) or whenever content exceeds the available space
+ * (popover/hover-card/navigation-menu, instead of overflowing like upstream).
+ * These `!important` deltas beat the inline styles and restore the upstream
+ * behavior. Menu-family panels (menu/select/context-menu/menubar)
+ * intentionally scroll per their authored strings and are untouched. */
+.cn-popover-content,
+.cn-tooltip-content,
+.cn-hover-card-content,
+.cn-navigation-menu-content {
+  @apply max-h-none! overflow-visible!;
+}
+
+/* Combobox content keeps its upstream height cap but must not scroll itself:
+ * upstream pairs `overflow-hidden` on the content with scrolling on the inner
+ * `cn-combobox-list`. The anchor's inline `overflow-y: auto` defeats the
+ * token's `overflow-hidden`, so re-assert it importantly. */
+.cn-combobox-content {
+  @apply overflow-hidden!;
+}
+
 /* sheet: upstream keys enter/exit motion on data-starting-style/
  * data-ending-style, which foldkit cannot emit — mapped to its
  * data-enter/data-leave transition windows instead. */

--- a/packages/registry/registry/default/style/cn-compat.css
+++ b/packages/registry/registry/default/style/cn-compat.css
@@ -137,6 +137,19 @@
   @apply overflow-hidden!;
 }
 
+/* Tooltip arrow centering: upstream centers the arrow on the trigger via the
+ * floating-ui arrow middleware (inline `left`/`top` on the Arrow element).
+ * Foldkit's tooltip primitive has no arrow support, and the authored arrow
+ * string carries no cross-axis centering for top/bottom sides (left/right
+ * already center via `top-1/2`), so the arrow sat at its static position —
+ * ~25px off-center. Center it on the panel instead. This matches upstream
+ * exactly when the trigger is centered and unshifted; with start/end align
+ * or shift displacement the arrow sits panel-centered rather than
+ * trigger-centered (true centering needs primitive arrow middleware). */
+.cn-tooltip-arrow {
+  @apply data-[side=bottom]:left-1/2 data-[side=bottom]:-translate-x-1/2 data-[side=top]:left-1/2 data-[side=top]:-translate-x-1/2;
+}
+
 /* `--anchor-width` bridge: upstream sizes dropdown/select/combobox panels to
  * the trigger (`w-(--anchor-width)`, combobox also
  * `min-w-[calc(var(--anchor-width)+--spacing(7))]`), resolving the var through

--- a/packages/registry/registry/default/ui/menubar.ts
+++ b/packages/registry/registry/default/ui/menubar.ts
@@ -45,8 +45,13 @@ export const menubarClass = 'cn-menubar flex items-center'
 /** Upstream menubar trigger token string. */
 export const menubarTriggerClass = 'cn-menubar-trigger flex items-center outline-hidden select-none'
 
+/** Upstream MenubarContent renders DropdownMenuContent (which owns the panel's
+ *  scroll-container utilities) with the menubar tokens layered on. Mirror that
+ *  composition so the panel scrolls intentionally like upstream instead of
+ *  relying on the anchor's inline overflow (whose computed overflow-x: auto
+ *  risks horizontal scrollbars). */
 export const menubarContentClass =
-  'cn-menubar-content cn-menubar-content-logical cn-menu-target cn-menu-translucent'
+  'cn-dropdown-menu-content cn-dropdown-menu-content-logical cn-menu-target cn-menu-translucent z-50 max-h-(--available-height) w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden cn-menubar-content cn-menubar-content-logical'
 
 export const menubarContentAnimatedClass = menubarContentClass
 


### PR DESCRIPTION
## Problem

Floating panels that never scroll upstream showed scrollbars in the demo:

- **Tooltip (every side):** the arrow deliberately protrudes past the panel's padding box (5px vertical on top/bottom, ~6px horizontal on left/right). The panel was a scroll container, so fitting content always scrolled.
- **Popover / hover-card / navigation-menu content:** panels scrolled internally whenever content exceeded the available space (verified: 230px popover content in a 400px viewport got `max-height: 178px` + scrollbar), instead of overflowing like upstream. The forced `overflow-y: auto` also computes `overflow-x` to `auto`, risking horizontal scrollbars.
- **Combobox content:** upstream pairs `overflow-hidden` on the content with scrolling on the inner `cn-combobox-list`; the forced inline `overflow-y: auto` defeated the token, adding a redundant outer scroll container.
- **Menubar content:** upstream `MenubarContent` renders `DropdownMenuContent` (which owns the panel's intentional scroll-container utilities); foldcn emitted bare menubar tokens, so the panel relied on the anchor's inline overflow with computed `overflow-x: auto`.
- **Sheet:** audited on all four sides, roomy + short viewports — no scrollbar; dialog engine writes no inline overflow. No change.

## Root cause

Not a token issue — resolved class strings already match `bases/base/ui` verbatim. foldkit's anchor `size` middleware (`@foldkit/ui` `anchor/anchor.js`) unconditionally writes inline `max-height: <available>px` + `overflow-y: auto` (+ `overscroll-behavior: none`) onto every anchored panel without an arrow element. Inline styles beat the authored classes, so upstream's no-scroll design never held. (`menu`/`select`/`context-menu` intentionally scroll per their authored strings and already agree with the inline styles — untouched.)

## Changed files (2, +33/-1)

- `packages/registry/registry/default/style/cn-compat.css` — new floating-panel delta block (repo-conventional home for foldkit deltas): `max-h-none! overflow-visible!` on `cn-popover-content`, `cn-tooltip-content`, `cn-hover-card-content`, `cn-navigation-menu-content` (the `!` beats the inline styles); `overflow-hidden!` on `cn-combobox-content` so the inner list owns scrolling. Resolves into all 9 style trees via the existing compat-first pipeline.
- `packages/registry/registry/default/ui/menubar.ts` — `menubarContentClass` now composes upstream's dropdown scroll-container utilities + menubar tokens, mirroring upstream `MenubarContent → DropdownMenuContent` (verbatim upstream utilities, same as `menu.ts` already does).

No edits to vendored `style-*.css`; no resolved Tailwind in authored sources beyond verbatim upstream strings; built with `pnpm --filter @foldcn/registry run build`.

## Test plan

- `pnpm --filter @foldcn/registry run build` — resolve asserts no `cn-*` leak; verified `overflow-visible!`/`max-h-none!`/`overflow-hidden!` land in the resolved default (+8 more) trees.
- `pnpm typecheck` ✅ · `pnpm test` (11 passed) ✅ · `pnpm lint` ✅ · `pnpm build` ✅.
- Web demo (agent-browser, dev server): tooltip top/right/bottom/left → `overflow: visible`, no scrollbar (default + vega styles); popover normal + 400px viewport → no internal scroll, overflows like upstream; hover-card, navigation-menu content, combobox (outer hidden, inner list scrolls), menubar, select → clean; sheet right/left/top/bottom → clean, unchanged.
- Screenshots: tooltip post-fix, popover in short viewport (no internal scrollbar), menubar open.

## Follow-ups (not in scope)

- `data-side` goes stale when floating-ui `flip` moves the panel (observed popover `placement=top` + `side=bottom`, nav-menu same) — wrong slide-in direction. Wants a placement-driven side or placement-keyed animation variants.
- `w-(--anchor-width)` / `max-h-(--available-height)` / `origin-(--transform-origin)` are dead vars under foldkit (it publishes `--button-width` + inline `maxHeight` instead of Base UI's vars) — menu/select/combobox panels size approximately, not exactly, like upstream.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix scrollbars and sizing on non-scrolling floating panels in registry CSS
> - Adds `!important` compatibility rules in [cn-compat.css](https://github.com/elianiva/foldcn/pull/47/files#diff-b39548a95807f202dc3c76247edabc798f39e68a65c3c5aacd868397e7678984) that strip the anchor primitive's inline `max-height` and vertical scroll from popover, tooltip, hover-card, and navigation-menu panels authored not to scroll
> - Restores `overflow: hidden` on combobox outer content so only the inner list scrolls
> - Centers tooltip arrows on top/bottom placements via placement-keyed translate rules
> - Bridges `anchor-width` for dropdown-menu, select, and combobox through a shared custom-property alias so panels size to the foldkit trigger width
> - Adds placement-keyed slide-in enter animations for all anchored panels, using the live foldkit placement instead of the static `side` attribute
> - Expands `menubarContentClass` in [menubar.ts](https://github.com/elianiva/foldcn/pull/47/files#diff-c9f9f9dff4a951ccf464dd55dd698efb83c6775037c5b130618ab7bc8d44681b) to compose dropdown-menu panel sizing and overflow utilities
> - Risk: the `!important` overrides in `cn-compat.css` target inline styles on anchor primitives; upstream styling that depends on those inline values for popover, tooltip, hover-card, or navigation-menu panels may be affected
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 87cbf52.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->