### PR TITLE
feat(menubar): close portable parity gaps vs upstream base registry

### DIFF
--- a/docs/shadcn-base-parity-audit.md
+++ b/docs/shadcn-base-parity-audit.md
@@ -83,7 +83,7 @@ Beyond styling, several foldcn components are missing their **defining behaviors
 - **select — MAJOR.** Flat options only (no groups/labels/separators/scroll arrows); activedescendant focus vs item focus; h-9/rounded-md vs h-8/rounded-lg material. Native `<select>` export ≈ base native-select.
 - **menu ↔ dropdown-menu — MAJOR.** Plain items only (no checkbox/radio/sub/destructive/inset); panel `min-w-48 rounded-md border` vs `min-w-32 rounded-lg ring-foreground/10`; zero data-slots; shortcut not accent-on-focus.
 - **context-menu — MAJOR.** Same gaps as menu + no pointer anchoring (bug #6).
-- **menubar — MAJOR.** Static bar of independent menus; no cross-menu keyboard model (bug #7); h-9 vs h-8 bar.
+- **menubar — MAJOR.** Bar of independent live menus (per-menu open/keyboard/typeahead/disabled/groups all work; anchor gap 8 = upstream sideOffset; group + checkbox/radio/sub token constants ported, demo covers every upstream example interactively). Still no cross-menu keyboard model (bug #7 — OPEN); submenu/checkbox/radio/destructive/inset item kinds need primitive work (demo uses labeled groups + state-managed check/radio rows).
 - **combobox — MAJOR.** Parent-owned filtering; no chips UI for multi-select, no clear button, no Empty row; panel metrics differ.
 - **command — MAJOR.** Presentational only (bug #8); item selection `bg-accent` vs base `bg-muted`.
 

--- a/packages/registry/registry/default/style/cn-compat.css
+++ b/packages/registry/registry/default/style/cn-compat.css
@@ -153,3 +153,13 @@
 .cn-input-group-button-size-sm {
   @apply gap-1;
 }
+
+/* menu panels: upstream's frosted-glass token (bg-popover/70 + a ::before
+ * backdrop-blur layer) does not reproduce under foldkit — the blur has no
+ * visible effect in foldcn's render, leaving raw see-through transparency on
+ * menubar/dropdown/context panels (upstream's deployed docs render these
+ * panels opaque). Pin the panel background opaque; authored strings keep
+ * cn-menu-translucent verbatim for upstream diffability. */
+.cn-menu-translucent {
+  @apply bg-popover;
+}

--- a/packages/registry/registry/default/ui/menubar.ts
+++ b/packages/registry/registry/default/ui/menubar.ts
@@ -26,13 +26,20 @@ export type Message = typeof Message.Type
 export const OutMessage = FoldkitMenu.OutMessage
 export type OutMessage = typeof OutMessage.Type
 
-// foldcn gaps vs upstream: each trigger is an independent Menu bundle — no
-// cross-menu arrow traversal or open-on-hover-of-next-trigger (needs a
-// menubar behavior primitive). Menubar content/item/label/separator/shortcut
-// now use correct cn-menubar-* family (was cn-dropdown-menu-*). Flat item
-// path only; checkbox/radio/submenu/destructive/inset require primitive work.
-// Per-item data-slot (menubar-item etc) cannot be stamped — primitive has no
-// per-item attribute hook.
+// foldcn gaps vs upstream (primitive ceiling — needs @foldkit/ui work): each
+// trigger is an independent Menu bundle — no cross-menu ArrowLeft/Right
+// traversal or open-on-hover-of-next-trigger (upstream Menubar primitive
+// behavior). No submenu/checkbox/radio item kinds (upstream MenubarSub,
+// MenubarCheckboxItem, MenubarRadioGroup/Item) — the Menu primitive has flat
+// items + labeled groups only; demo state can toggle check/radio affordances
+// (see the web menubar demo). No per-item data-inset/data-variant attributes
+// (upstream MenubarItem inset/destructive props) and no per-item data-slot
+// (menubar-item etc) — the primitive has no per-item attribute hook.
+// Menubar content/item/label/separator/shortcut use the cn-menubar-* family.
+// Group headings render via itemGroupKey/groupToHeading (upstream
+// MenubarGroup/MenubarLabel); separators render between groups. The panel is
+// portaled to the document body by the primitive itself (upstream
+// MenubarPortal equivalent). Align offset (-4) has no anchor equivalent.
 
 export type Bundle<Item extends string = string> = FoldkitMenu.Bundle<Item>
 export type InitConfig = FoldkitMenu.InitConfig
@@ -57,15 +64,43 @@ export const menubarSeparatorClass = 'cn-menubar-separator -mx-1 my-1 h-px'
 
 export const menubarHeadingClass = 'cn-menubar-label'
 
+/** Upstream `MenubarLabel` token (alias — foldcn historically named it heading). */
+export const menubarLabelClass = menubarHeadingClass
+
 export const menubarShortcutClass = 'cn-menubar-shortcut ml-auto'
+
+/** Upstream `MenubarCheckboxItem` token string (verbatim). No foldkit highlight
+ *  twin: upstream keys checkbox highlight on focus: inside the token. */
+export const menubarCheckboxItemClass =
+  'cn-menubar-checkbox-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0'
+
+export const menubarCheckboxItemIndicatorClass =
+  'cn-menubar-checkbox-item-indicator pointer-events-none absolute flex items-center justify-center'
+
+/** Upstream `MenubarRadioItem` token string (verbatim — note: no disabled
+ *  opacity, matching upstream). */
+export const menubarRadioItemClass =
+  'cn-menubar-radio-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0'
+
+export const menubarRadioItemIndicatorClass =
+  'cn-menubar-radio-item-indicator pointer-events-none absolute flex items-center justify-center'
+
+/** Upstream `MenubarSubTrigger` token (verbatim). Open-state styling arrives
+ *  via cn-compat.css twins (foldkit emits data-open, Base UI data-popup-open). */
+export const menubarSubTriggerClass = 'cn-menubar-sub-trigger'
+
+/** Upstream `MenubarSubContent` token string (verbatim). */
+export const menubarSubContentClass = 'cn-menubar-sub-content cn-menu-target cn-menu-translucent'
 
 export const menubarBackdropClass = 'fixed inset-0 z-0'
 
 export const menubarWrapperClass = 'relative inline-block'
 
+// Upstream MenubarContent: align=start (placement bottom-start), sideOffset=8
+// (gap), alignOffset=-4 (no anchor equivalent — documented gap above).
 export const MENUBAR_ANCHOR: AnchorConfig = {
   placement: 'bottom-start',
-  gap: 4,
+  gap: 8,
   padding: 8,
 }
 
@@ -78,12 +113,15 @@ export type MenubarViewInputsConfig<Item extends string> = Readonly<{
   itemToSearchText?: (item: Item, index: number) => string
   isButtonDisabled?: boolean
   isAnimated?: boolean
+  itemGroupKey?: (item: Item, index: number) => string
+  groupToHeading?: (groupKey: string) => GroupHeading | undefined
   triggerClass?: string
   itemsClass?: string
   itemClass?: string
   backdropClass?: string
   wrapperClass?: string
   separatorClass?: string
+  groupClass?: string
   ariaLabel?: string
   ariaLabelledBy?: string
 }>
@@ -98,6 +136,17 @@ export const viewInputs = <Item extends string>(
   itemToSearchText: config.itemToSearchText,
   isButtonDisabled: config.isButtonDisabled,
   buttonContent: config.buttonContent,
+  itemGroupKey: config.itemGroupKey,
+  groupToHeading: config.groupToHeading
+    ? (groupKey) => {
+        const heading = config.groupToHeading!(groupKey)
+        if (!heading) return undefined
+        return {
+          content: heading.content,
+          className: cn(menubarHeadingClass, heading.className),
+        }
+      }
+    : undefined,
   ariaLabel: config.ariaLabel,
   ariaLabelledBy: config.ariaLabelledBy,
   buttonClassName: cn(menubarTriggerClass, config.triggerClass),
@@ -113,6 +162,8 @@ export const viewInputs = <Item extends string>(
   },
   separatorClassName: cn(menubarSeparatorClass, config.separatorClass),
   separatorAttributes: childAttributes([inertHtml.DataAttribute('slot', 'menubar-separator')]),
+  groupClassName: config.groupClass,
+  groupAttributes: childAttributes([inertHtml.DataAttribute('slot', 'menubar-group')]),
   backdropClassName: cn(menubarBackdropClass, config.backdropClass),
   className: cn(menubarWrapperClass, config.wrapperClass),
   attributes: childAttributes([inertHtml.DataAttribute('slot', 'menubar')]),

--- a/packages/web/src/demo/assemble.ts
+++ b/packages/web/src/demo/assemble.ts
@@ -318,6 +318,7 @@ export const update = (model: Model, message: Message): DemoUpdateReturn => {
       ...listboxSlice.handlers(model),
       ...loginFormSlice.handlers(model),
       ...menuSlice.handlers(model),
+      ...menubarSlice.handlers(model),
       ...navSlice.handlers(model),
       ...navigationMenuSlice.handlers(model),
       ...nativeSelectSlice.handlers(model),

--- a/packages/web/src/demo/views/menubar.ts
+++ b/packages/web/src/demo/views/menubar.ts
@@ -1,106 +1,444 @@
+import { Update } from 'foldkit'
+import { Match as M, Option } from 'effect'
+import { Schema as S } from 'effect'
+import { evo } from 'foldkit/struct'
+import { defineMessageUnion } from 'foldkit/message'
 import type { Html, HtmlBuilder } from 'foldkit/html'
 
+import { Menu as FoldkitMenu } from '@foldkit/ui'
+import { Check, CircleHelp, File, Folder, Save, Settings, Trash2 } from 'lucide'
+import type { IconNode } from 'lucide'
+
 import * as Menubar from '../../generated/registry/ui/menubar'
+import * as menu from '../../generated/registry/ui/menu'
+import { icon } from '../../generated/registry/lib/icons'
+
 import { DemoMenu } from '../bundles'
 
-import { defineSlice } from '../slice'
-import type { Model, Message } from '../assemble'
+import { defineSlice, type UpdateReturn } from '../slice'
+import type { Model, Message as AppMessage } from '../assemble'
 
-import { Message as MenuMessage } from './menu'
+export const Message = defineMessageUnion({
+  GotFileMessage: { message: menu.Message },
+  GotEditMessage: { message: menu.Message },
+  GotViewMessage: { message: menu.Message },
+  GotProfilesMessage: { message: menu.Message },
+  GotSubFileMessage: { message: menu.Message },
+  GotSubEditMessage: { message: menu.Message },
+  GotCheckViewMessage: { message: menu.Message },
+  GotCheckFormatMessage: { message: menu.Message },
+  GotRadioProfilesMessage: { message: menu.Message },
+  GotRadioThemeMessage: { message: menu.Message },
+  GotIconFileMessage: { message: menu.Message },
+  GotIconMoreMessage: { message: menu.Message },
+  GotRtlFileMessage: { message: menu.Message },
+})
 
-export const menubarView = (model: Model, h: HtmlBuilder<Message>): Html =>
+// Mirrors apps/v4/examples/base/menubar-*.tsx. Every bar below is a live menu:
+// keyboard nav, typeahead, disabled items, groups/separators, and selection
+// all work. Primitive-ceiling approximations (see the notes section at the
+// bottom of the view): submenus render as labeled groups (Share/Find), check
+// and radio rows toggle slice state on select (the menu closes — upstream
+// keeps it open), inset uses pl-7 (no per-item data-inset hook), and the
+// destructive Delete row uses text-destructive (no per-item data-variant hook).
+
+const shortcut = (h: HtmlBuilder<AppMessage>, text: string): Html =>
+  h.span([h.Class(Menubar.menubarShortcutClass)], [text])
+
+// Row wrappers use display:contents so icons/labels/shortcuts participate in
+// the menu item's own flex layout directly (upstream renders them as direct
+// children — the shortcut's ml-auto only works as a flex item).
+const rowClass = 'contents'
+
+const labelRow = (h: HtmlBuilder<AppMessage>, label: string, text?: string): Html =>
+  h.span([h.Class(rowClass)], text === undefined ? [label] : [label, shortcut(h, text)])
+
+const checkRow = (
+  h: HtmlBuilder<AppMessage>,
+  label: string,
+  checked: boolean,
+  text?: string,
+): Html =>
+  h.span(
+    [h.Class(rowClass)],
+    [
+      h.span([h.Class(Menubar.menubarCheckboxItemIndicatorClass)], checked ? [icon(h, Check)] : []),
+      label,
+      ...(text === undefined ? [] : [shortcut(h, text)]),
+    ],
+  )
+
+const radioRow = (h: HtmlBuilder<AppMessage>, label: string, selected: boolean): Html =>
+  h.span(
+    [h.Class(rowClass)],
+    [
+      h.span([h.Class(Menubar.menubarRadioItemIndicatorClass)], selected ? [icon(h, Check)] : []),
+      label,
+    ],
+  )
+
+const iconRow = (
+  h: HtmlBuilder<AppMessage>,
+  iconNode: IconNode,
+  label: string,
+  text?: string,
+): Html =>
+  h.span(
+    [h.Class(rowClass)],
+    [icon(h, iconNode), label, ...(text === undefined ? [] : [shortcut(h, text)])],
+  )
+
+// Upstream menubar-demo.tsx items, in order. Inset rows (upstream `inset`)
+// add pl-7 — the token's data-inset:pl-7 never matches because the primitive
+// has no per-item attribute hook.
+const INSET = 'pl-7'
+
+// Checkbox/radio rows use the upstream checkbox/radio token classes (pl-7 room
+// for the indicator) plus the foldkit data-active highlight twin.
+const checkItemClass = `${Menubar.menubarCheckboxItemClass} data-active:bg-accent data-active:text-accent-foreground`
+const radioItemClass = `${Menubar.menubarRadioItemClass} data-active:bg-accent data-active:text-accent-foreground`
+
+const fileItems = [
+  'New Tab',
+  'New Window',
+  'New Incognito Window',
+  'Email link',
+  'Messages',
+  'Notes',
+  'Print…',
+] as const
+
+const fileGroupKey = (item: string): string => {
+  if (item === 'Email link' || item === 'Messages' || item === 'Notes') return 'share'
+  if (item === 'Print…') return 'print'
+  return 'main'
+}
+
+const editItems = [
+  'Undo',
+  'Redo',
+  'Search the web',
+  'Find…',
+  'Find Next',
+  'Find Previous',
+  'Cut',
+  'Copy',
+  'Paste',
+] as const
+
+const editGroupKey = (item: string): string => {
+  if (
+    item === 'Search the web' ||
+    item === 'Find…' ||
+    item === 'Find Next' ||
+    item === 'Find Previous'
+  )
+    return 'find'
+  if (item === 'Cut' || item === 'Copy' || item === 'Paste') return 'action'
+  return 'main'
+}
+
+const fileContent = (h: HtmlBuilder<AppMessage>, item: string): Html => {
+  switch (item) {
+    case 'New Tab':
+      return labelRow(h, 'New Tab', '⌘T')
+    case 'New Window':
+      return labelRow(h, 'New Window', '⌘N')
+    case 'Print…':
+      return labelRow(h, 'Print…', '⌘P')
+    default:
+      return labelRow(h, item)
+  }
+}
+
+const editContent = (h: HtmlBuilder<AppMessage>, item: string): Html => {
+  switch (item) {
+    case 'Undo':
+      return labelRow(h, 'Undo', '⌘Z')
+    case 'Redo':
+      return labelRow(h, 'Redo', '⇧⌘Z')
+    default:
+      return labelRow(h, item)
+  }
+}
+
+const bar = (h: HtmlBuilder<AppMessage>, children: ReadonlyArray<Html>, className = 'w-72'): Html =>
+  h.div(
+    [h.Class('rounded-lg border p-3')],
+    [Menubar.menubar([h.div([h.Class(className)], children)], h)],
+  )
+
+export const menubarView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
   h.div(
     [h.Class('flex w-full flex-col gap-8')],
     [
       h.div(
         [h.Class('flex w-full flex-col gap-2')],
         [
-          h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], ['Basic']),
-          Menubar.menubar(
-            [
-              h.submodel({
-                slotId: model.menu.id,
-                model: model.menu,
-                view: DemoMenu.view,
-                viewInputs: Menubar.viewInputs<string>({
-                  items: ['New Tab', 'New Window', 'New Incognito Window', 'Share', 'Print…'],
-                  buttonContent: h.span([], ['File']),
-                  itemToConfig: (item, { isActive }) => ({
-                    className: isActive ? 'font-medium' : '',
-                    content: h.span([], [item]),
-                  }),
-                }),
-                toParentMessage: (message) => MenuMessage.GotMenuMessage({ message }),
+          h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], ['Demo']),
+          bar(h, [
+            h.submodel({
+              slotId: model.fileMenu.id,
+              model: model.fileMenu,
+              view: DemoMenu.view,
+              viewInputs: Menubar.viewInputs<string>({
+                items: [...fileItems],
+                buttonContent: h.span([], ['File']),
+                itemToConfig: (item) => ({ content: fileContent(h, item) }),
+                isItemDisabled: (item) => item === 'New Incognito Window',
+                itemGroupKey: (item) => fileGroupKey(item),
+                groupToHeading: (groupKey) =>
+                  groupKey === 'share' ? { content: h.span([], ['Share']) } : undefined,
               }),
-              h.button([h.Class(Menubar.menubarTriggerClass)], ['Edit']),
-              h.button([h.Class(Menubar.menubarTriggerClass)], ['View']),
-              h.button([h.Class(Menubar.menubarTriggerClass)], ['Profiles']),
-            ],
-            h,
-          ),
-          h.p(
-            [h.Class('px-1 text-xs text-muted-foreground')],
-            [
-              'Interactive File menu — other triggers (Edit/View/Profiles) are visual affordances. No cross-menu arrow traversal in foldcn.',
-            ],
-          ),
+              toParentMessage: (message) => Message.GotFileMessage({ message }),
+            }),
+            h.submodel({
+              slotId: model.editMenu.id,
+              model: model.editMenu,
+              view: DemoMenu.view,
+              viewInputs: Menubar.viewInputs<string>({
+                items: [...editItems],
+                buttonContent: h.span([], ['Edit']),
+                itemToConfig: (item) => ({ content: editContent(h, item) }),
+                itemGroupKey: (item) => editGroupKey(item),
+                groupToHeading: (groupKey) =>
+                  groupKey === 'find' ? { content: h.span([], ['Find']) } : undefined,
+              }),
+              toParentMessage: (message) => Message.GotEditMessage({ message }),
+            }),
+            h.submodel({
+              slotId: model.viewMenu.id,
+              model: model.viewMenu,
+              view: DemoMenu.view,
+              viewInputs: Menubar.viewInputs<string>({
+                items: [
+                  'Bookmarks Bar',
+                  'Full URLs',
+                  'Reload',
+                  'Force Reload',
+                  'Toggle Fullscreen',
+                  'Hide Sidebar',
+                ],
+                buttonContent: h.span([], ['View']),
+                itemsClass: 'w-44',
+                itemToConfig: (item) => {
+                  switch (item) {
+                    case 'Bookmarks Bar':
+                      return {
+                        className: checkItemClass,
+                        content: checkRow(h, 'Bookmarks Bar', model.showBookmarks),
+                      }
+                    case 'Full URLs':
+                      return {
+                        className: checkItemClass,
+                        content: checkRow(h, 'Full URLs', model.showFullUrls),
+                      }
+                    case 'Reload':
+                      return {
+                        className: INSET,
+                        content: labelRow(h, 'Reload', '⌘R'),
+                      }
+                    case 'Force Reload':
+                      return {
+                        className: INSET,
+                        content: labelRow(h, 'Force Reload', '⇧⌘R'),
+                      }
+                    default:
+                      return { className: INSET, content: labelRow(h, item) }
+                  }
+                },
+                isItemDisabled: (item) => item === 'Force Reload',
+                itemGroupKey: (item) =>
+                  item === 'Bookmarks Bar' || item === 'Full URLs'
+                    ? 'checks'
+                    : item === 'Reload' || item === 'Force Reload'
+                      ? 'reload'
+                      : item === 'Toggle Fullscreen'
+                        ? 'fullscreen'
+                        : 'sidebar',
+              }),
+              toParentMessage: (message) => Message.GotViewMessage({ message }),
+            }),
+            h.submodel({
+              slotId: model.profilesMenu.id,
+              model: model.profilesMenu,
+              view: DemoMenu.view,
+              viewInputs: Menubar.viewInputs<string>({
+                items: ['Andy', 'Benoit', 'Luis', 'Edit…', 'Add Profile…'],
+                buttonContent: h.span([], ['Profiles']),
+                itemToConfig: (item) => {
+                  if (item === 'Edit…' || item === 'Add Profile…')
+                    return { className: INSET, content: labelRow(h, item) }
+                  return {
+                    className: radioItemClass,
+                    content: radioRow(h, item, model.profile === item),
+                  }
+                },
+                itemGroupKey: (item) =>
+                  item === 'Edit…' ? 'edit' : item === 'Add Profile…' ? 'add' : 'profiles',
+              }),
+              toParentMessage: (message) => Message.GotProfilesMessage({ message }),
+            }),
+          ]),
         ],
       ),
       h.div(
         [h.Class('flex w-full flex-col gap-2')],
         [
           h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], ['With Submenu']),
-          h.div(
-            [h.Class('rounded-lg border p-3 text-sm')],
-            [
-              'File → Share → Email / Messages / Notes; Edit → Find → Find / Find Next / Find Previous (submenus).',
-            ],
-          ),
-        ],
-      ),
-      h.div(
-        [h.Class('flex w-full flex-col gap-2')],
-        [
-          h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], ['Sides']),
-          h.div(
-            [h.Class('flex flex-wrap gap-2 text-xs')],
-            [
-              h.span([h.Class('rounded border px-2 py-1')], ['inline-start']),
-              h.span([h.Class('rounded border px-2 py-1')], ['top']),
-              h.span([h.Class('rounded border px-2 py-1')], ['bottom']),
-              h.span([h.Class('rounded border px-2 py-1')], ['right']),
-            ],
-          ),
           h.p(
             [h.Class('px-1 text-xs text-muted-foreground')],
-            ['MenubarContent side per menu — static preview.'],
+            ['Share and Find have no submenu primitive — they render as labeled groups.'],
           ),
+          bar(h, [
+            h.submodel({
+              slotId: model.subFileMenu.id,
+              model: model.subFileMenu,
+              view: DemoMenu.view,
+              viewInputs: Menubar.viewInputs<string>({
+                items: ['Email link', 'Messages', 'Notes', 'Print…'],
+                buttonContent: h.span([], ['File']),
+                itemToConfig: (item) => ({ content: fileContent(h, item) }),
+                itemGroupKey: (item) => (item === 'Print…' ? 'print' : 'share'),
+                groupToHeading: (groupKey) =>
+                  groupKey === 'share' ? { content: h.span([], ['Share']) } : undefined,
+              }),
+              toParentMessage: (message) => Message.GotSubFileMessage({ message }),
+            }),
+            h.submodel({
+              slotId: model.subEditMenu.id,
+              model: model.subEditMenu,
+              view: DemoMenu.view,
+              viewInputs: Menubar.viewInputs<string>({
+                items: [
+                  'Undo',
+                  'Redo',
+                  'Find…',
+                  'Find Next',
+                  'Find Previous',
+                  'Cut',
+                  'Copy',
+                  'Paste',
+                ],
+                buttonContent: h.span([], ['Edit']),
+                itemToConfig: (item) => ({ content: editContent(h, item) }),
+                itemGroupKey: (item) => editGroupKey(item),
+                groupToHeading: (groupKey) =>
+                  groupKey === 'find' ? { content: h.span([], ['Find']) } : undefined,
+              }),
+              toParentMessage: (message) => Message.GotSubEditMessage({ message }),
+            }),
+          ]),
         ],
       ),
       h.div(
         [h.Class('flex w-full flex-col gap-2')],
         [
           h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], ['With Checkboxes']),
-          h.div(
-            [h.Class('rounded-lg border p-3 text-sm flex flex-col gap-1')],
-            [
-              h.div([], ['Always Show Bookmarks Bar — unchecked']),
-              h.div([], ['Always Show Full URLs — checked']),
-              h.div([h.Class('border-t my-1')], []),
-              h.div([], ['Format → Strikethrough (checked) / Code / Superscript']),
-            ],
-          ),
+          bar(h, [
+            h.submodel({
+              slotId: model.checkViewMenu.id,
+              model: model.checkViewMenu,
+              view: DemoMenu.view,
+              viewInputs: Menubar.viewInputs<string>({
+                items: [
+                  'Always Show Bookmarks Bar',
+                  'Always Show Full URLs',
+                  'Reload',
+                  'Force Reload',
+                ],
+                buttonContent: h.span([], ['View']),
+                itemsClass: 'w-64',
+                itemToConfig: (item) => {
+                  switch (item) {
+                    case 'Always Show Bookmarks Bar':
+                      return {
+                        className: checkItemClass,
+                        content: checkRow(h, 'Always Show Bookmarks Bar', model.showBookmarks),
+                      }
+                    case 'Always Show Full URLs':
+                      return {
+                        className: checkItemClass,
+                        content: checkRow(h, 'Always Show Full URLs', model.showFullUrls),
+                      }
+                    case 'Reload':
+                      return {
+                        className: INSET,
+                        content: labelRow(h, 'Reload', '⌘R'),
+                      }
+                    default:
+                      return {
+                        className: INSET,
+                        content: labelRow(h, 'Force Reload', '⇧⌘R'),
+                      }
+                  }
+                },
+                isItemDisabled: (item) => item === 'Force Reload',
+                itemGroupKey: (item) =>
+                  item === 'Reload' || item === 'Force Reload' ? 'reload' : 'checks',
+              }),
+              toParentMessage: (message) => Message.GotCheckViewMessage({ message }),
+            }),
+            h.submodel({
+              slotId: model.checkFormatMenu.id,
+              model: model.checkFormatMenu,
+              view: DemoMenu.view,
+              viewInputs: Menubar.viewInputs<string>({
+                items: ['Strikethrough', 'Code', 'Superscript'],
+                buttonContent: h.span([], ['Format']),
+                itemToConfig: (item) => ({
+                  className: checkItemClass,
+                  content: checkRow(h, item, model.checkedFormats.includes(item)),
+                }),
+              }),
+              toParentMessage: (message) => Message.GotCheckFormatMessage({ message }),
+            }),
+          ]),
         ],
       ),
       h.div(
         [h.Class('flex w-full flex-col gap-2')],
         [
           h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], ['With Radio']),
-          h.div(
-            [h.Class('rounded-lg border p-3 text-sm')],
-            [
-              'Profiles: Andy / Benoit (selected) / Luis · Theme: Light / Dark / System — radio groups with Edit / Add Profile inset items.',
-            ],
+          bar(h, [
+            h.submodel({
+              slotId: model.radioProfilesMenu.id,
+              model: model.radioProfilesMenu,
+              view: DemoMenu.view,
+              viewInputs: Menubar.viewInputs<string>({
+                items: ['Andy', 'Benoit', 'Luis', 'Edit…', 'Add Profile…'],
+                buttonContent: h.span([], ['Profiles']),
+                itemToConfig: (item) => {
+                  if (item === 'Edit…' || item === 'Add Profile…')
+                    return { className: INSET, content: labelRow(h, item) }
+                  return {
+                    className: radioItemClass,
+                    content: radioRow(h, item, model.profile === item),
+                  }
+                },
+                itemGroupKey: (item) =>
+                  item === 'Edit…' ? 'edit' : item === 'Add Profile…' ? 'add' : 'profiles',
+              }),
+              toParentMessage: (message) => Message.GotRadioProfilesMessage({ message }),
+            }),
+            h.submodel({
+              slotId: model.radioThemeMenu.id,
+              model: model.radioThemeMenu,
+              view: DemoMenu.view,
+              viewInputs: Menubar.viewInputs<string>({
+                items: ['Light', 'Dark', 'System'],
+                buttonContent: h.span([], ['Theme']),
+                itemToConfig: (item) => ({
+                  className: radioItemClass,
+                  content: radioRow(h, item, model.theme === item),
+                }),
+              }),
+              toParentMessage: (message) => Message.GotRadioThemeMessage({ message }),
+            }),
+          ]),
+          h.p(
+            [h.Class('px-1 text-xs text-muted-foreground')],
+            [`Selected profile: ${model.profile} · theme: ${model.theme}`],
           ),
         ],
       ),
@@ -111,26 +449,82 @@ export const menubarView = (model: Model, h: HtmlBuilder<Message>): Html =>
             [h.Class('px-1 text-xs font-medium text-muted-foreground')],
             ['With Icons & Shortcuts'],
           ),
-          h.div(
-            [h.Class('rounded-lg border p-3 text-sm')],
-            [
-              'File → New File ⌘N · Open Folder · Save ⌘S; More → Settings / Help / Delete (destructive) with icons.',
-            ],
-          ),
+          bar(h, [
+            h.submodel({
+              slotId: model.iconFileMenu.id,
+              model: model.iconFileMenu,
+              view: DemoMenu.view,
+              viewInputs: Menubar.viewInputs<string>({
+                items: ['New File', 'Open Folder', 'Save'],
+                buttonContent: h.span([], ['File']),
+                itemToConfig: (item) => {
+                  switch (item) {
+                    case 'New File':
+                      return { content: iconRow(h, File, 'New File', '⌘N') }
+                    case 'Open Folder':
+                      return { content: iconRow(h, Folder, 'Open Folder') }
+                    default:
+                      return { content: iconRow(h, Save, 'Save', '⌘S') }
+                  }
+                },
+                itemGroupKey: (item) => (item === 'Save' ? 'save' : 'new'),
+              }),
+              toParentMessage: (message) => Message.GotIconFileMessage({ message }),
+            }),
+            h.submodel({
+              slotId: model.iconMoreMenu.id,
+              model: model.iconMoreMenu,
+              view: DemoMenu.view,
+              viewInputs: Menubar.viewInputs<string>({
+                items: ['Settings', 'Help', 'Delete'],
+                buttonContent: h.span([], ['More']),
+                itemToConfig: (item) => {
+                  switch (item) {
+                    case 'Settings':
+                      return { content: iconRow(h, Settings, 'Settings') }
+                    case 'Help':
+                      return { content: iconRow(h, CircleHelp, 'Help') }
+                    default:
+                      return {
+                        className: 'text-destructive',
+                        content: iconRow(h, Trash2, 'Delete'),
+                      }
+                  }
+                },
+                itemGroupKey: (item) => (item === 'Delete' ? 'danger' : 'main'),
+              }),
+              toParentMessage: (message) => Message.GotIconMoreMessage({ message }),
+            }),
+          ]),
         ],
       ),
       h.div(
         [h.Class('flex w-full flex-col gap-2')],
         [
-          h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], ['Format & Insert']),
+          h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], ['RTL']),
           h.div(
-            [h.Class('rounded-lg border p-3 text-sm flex flex-col gap-1')],
+            [h.Class('rounded-lg border p-3'), h.Attribute('dir', 'rtl')],
             [
-              h.div(
-                [],
-                ['Format → Bold ⌘B · Italic ⌘I · Underline ⌘U + Strikethrough/Code checkboxes'],
+              Menubar.menubar(
+                [
+                  h.submodel({
+                    slotId: model.rtlFileMenu.id,
+                    model: model.rtlFileMenu,
+                    view: DemoMenu.view,
+                    viewInputs: Menubar.viewInputs<string>({
+                      items: [...fileItems],
+                      buttonContent: h.span([], ['File']),
+                      itemToConfig: (item) => ({ content: fileContent(h, item) }),
+                      isItemDisabled: (item) => item === 'New Incognito Window',
+                      itemGroupKey: (item) => fileGroupKey(item),
+                      groupToHeading: (groupKey) =>
+                        groupKey === 'share' ? { content: h.span([], ['Share']) } : undefined,
+                    }),
+                    toParentMessage: (message) => Message.GotRtlFileMessage({ message }),
+                  }),
+                ],
+                h,
               ),
-              h.div([], ['Insert → Media submenu (Image/Video/Audio) + Link ⌘K + Table']),
             ],
           ),
         ],
@@ -138,35 +532,28 @@ export const menubarView = (model: Model, h: HtmlBuilder<Message>): Html =>
       h.div(
         [h.Class('flex w-full flex-col gap-2')],
         [
-          h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], ['Destructive']),
-          h.div(
-            [h.Class('rounded-lg border p-3 text-sm')],
+          h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], ['Behavior notes']),
+          h.ul(
+            [h.Class('flex list-disc flex-col gap-1 px-5 text-xs text-muted-foreground')],
             [
-              'File → Delete File ⌘⌫ (destructive) · Account → Profile / Settings / Sign out (destructive) / Delete (destructive).',
-            ],
-          ),
-        ],
-      ),
-      h.div(
-        [h.Class('flex w-full flex-col gap-2')],
-        [
-          h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], ['In Dialog']),
-          h.div(
-            [h.Class('rounded-lg border p-3 text-sm text-muted-foreground')],
-            [
-              'Dialog with a menubar inside — File: Copy/Cut/Paste + More Options submenu; Edit: Undo/Redo.',
-            ],
-          ),
-        ],
-      ),
-      h.div(
-        [h.Class('flex w-full flex-col gap-2')],
-        [
-          h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], ['With Inset']),
-          h.div(
-            [h.Class('rounded-lg border p-3 text-sm')],
-            [
-              'View → Copy / Cut / Paste (inset) + Bookmarks / Full URLs (inset checkboxes) + Theme radios (inset) + More Options submenu (inset).',
+              h.li(
+                [],
+                [
+                  'Each trigger is an independent menu — no ArrowLeft/Right traversal between menus and no open-on-hover-of-next-trigger (needs a menubar behavior primitive).',
+                ],
+              ),
+              h.li(
+                [],
+                [
+                  'Submenus (Share, Find) render as labeled groups; checkbox and radio rows toggle state on select and the menu closes (upstream keeps it open).',
+                ],
+              ),
+              h.li(
+                [],
+                [
+                  'Inset rows use pl-7 and Delete uses text-destructive — the primitive has no per-item data-inset/data-variant hook.',
+                ],
+              ),
             ],
           ),
         ],
@@ -174,9 +561,239 @@ export const menubarView = (model: Model, h: HtmlBuilder<Message>): Html =>
     ],
   )
 
+const foldNoOp =
+  <Out>(): ((out: Out) => Update.Step<State, unknown>) =>
+  () =>
+  (model) => ({ model })
+
+const foldIgnoredOutMessage = M.type<FoldkitMenu.OutMessage>().pipe(
+  M.withReturnType<Update.Step<State, unknown>>(),
+  M.tagsExhaustive({ Selected: foldNoOp() }),
+)
+
+// Bookmarks/Full URLs checkboxes (demo-bar View + checkbox-section View share
+// state — labels differ, values map to the same flags).
+const foldCheckOutMessage = M.type<FoldkitMenu.OutMessage>().pipe(
+  M.withReturnType<Update.Step<State, unknown>>(),
+  M.tagsExhaustive({
+    Selected:
+      ({ value }) =>
+      (model) =>
+        value === 'Bookmarks Bar' || value === 'Always Show Bookmarks Bar'
+          ? { model: evo(model, { showBookmarks: () => !model.showBookmarks }) }
+          : value === 'Full URLs' || value === 'Always Show Full URLs'
+            ? { model: evo(model, { showFullUrls: () => !model.showFullUrls }) }
+            : { model },
+  }),
+)
+
+const foldFormatOutMessage = M.type<FoldkitMenu.OutMessage>().pipe(
+  M.withReturnType<Update.Step<State, unknown>>(),
+  M.tagsExhaustive({
+    Selected:
+      ({ value }) =>
+      (model) => ({
+        model: evo(model, {
+          checkedFormats: () =>
+            model.checkedFormats.includes(value)
+              ? model.checkedFormats.filter((entry) => entry !== value)
+              : [...model.checkedFormats, value],
+        }),
+      }),
+  }),
+)
+
+const foldProfileOutMessage = M.type<FoldkitMenu.OutMessage>().pipe(
+  M.withReturnType<Update.Step<State, unknown>>(),
+  M.tagsExhaustive({
+    Selected:
+      ({ value }) =>
+      (model) => ({
+        model: evo(model, { profile: () => value }),
+      }),
+  }),
+)
+
+const foldThemeOutMessage = M.type<FoldkitMenu.OutMessage>().pipe(
+  M.withReturnType<Update.Step<State, unknown>>(),
+  M.tagsExhaustive({
+    Selected:
+      ({ value }) =>
+      (model) => ({
+        model: evo(model, { theme: () => value }),
+      }),
+  }),
+)
+
+// One foldChild per menu field (mirrors the menu slice shape) — the read/write
+// pair below is per-field so inference stays on the proven path.
+
+const fields = {
+  fileMenu: menu.Model,
+  editMenu: menu.Model,
+  viewMenu: menu.Model,
+  profilesMenu: menu.Model,
+  subFileMenu: menu.Model,
+  subEditMenu: menu.Model,
+  checkViewMenu: menu.Model,
+  checkFormatMenu: menu.Model,
+  radioProfilesMenu: menu.Model,
+  radioThemeMenu: menu.Model,
+  iconFileMenu: menu.Model,
+  iconMoreMenu: menu.Model,
+  rtlFileMenu: menu.Model,
+  showBookmarks: S.Boolean,
+  showFullUrls: S.Boolean,
+  checkedFormats: S.Array(S.String),
+  profile: S.String,
+  theme: S.String,
+}
+
+const stateSchema = S.Struct(fields)
+type State = typeof stateSchema.Type
+
 export const slice = defineSlice({
-  fields: {},
-  init: {},
-  messages: [],
-  handlers: () => ({}),
+  fields,
+  init: {
+    fileMenu: menu.init({ id: 'menubar-file' }),
+    editMenu: menu.init({ id: 'menubar-edit' }),
+    viewMenu: menu.init({ id: 'menubar-view' }),
+    profilesMenu: menu.init({ id: 'menubar-profiles' }),
+    subFileMenu: menu.init({ id: 'menubar-sub-file' }),
+    subEditMenu: menu.init({ id: 'menubar-sub-edit' }),
+    checkViewMenu: menu.init({ id: 'menubar-check-view' }),
+    checkFormatMenu: menu.init({ id: 'menubar-check-format' }),
+    radioProfilesMenu: menu.init({ id: 'menubar-radio-profiles' }),
+    radioThemeMenu: menu.init({ id: 'menubar-radio-theme' }),
+    iconFileMenu: menu.init({ id: 'menubar-icon-file' }),
+    iconMoreMenu: menu.init({ id: 'menubar-icon-more' }),
+    rtlFileMenu: menu.init({ id: 'menubar-rtl-file' }),
+    showBookmarks: false,
+    showFullUrls: true,
+    checkedFormats: ['Strikethrough'],
+    profile: 'Benoit',
+    theme: 'System',
+  },
+  messages: [
+    Message.GotFileMessage,
+    Message.GotEditMessage,
+    Message.GotViewMessage,
+    Message.GotProfilesMessage,
+    Message.GotSubFileMessage,
+    Message.GotSubEditMessage,
+    Message.GotCheckViewMessage,
+    Message.GotCheckFormatMessage,
+    Message.GotRadioProfilesMessage,
+    Message.GotRadioThemeMessage,
+    Message.GotIconFileMessage,
+    Message.GotIconMoreMessage,
+    Message.GotRtlFileMessage,
+  ],
+  handlers: (model: State) => ({
+    GotFileMessage: (payload: typeof Message.GotFileMessage.Type): UpdateReturn =>
+      Update.foldChild({
+        update: DemoMenu.update,
+        read: (state: State) => Option.some(state.fileMenu),
+        write: (state, next) => evo(state, { fileMenu: () => next }),
+        toParentMessage: (message) => Message.GotFileMessage({ message }),
+        foldOutMessage: foldIgnoredOutMessage,
+      })(model, payload.message),
+    GotEditMessage: (payload: typeof Message.GotEditMessage.Type): UpdateReturn =>
+      Update.foldChild({
+        update: DemoMenu.update,
+        read: (state: State) => Option.some(state.editMenu),
+        write: (state, next) => evo(state, { editMenu: () => next }),
+        toParentMessage: (message) => Message.GotEditMessage({ message }),
+        foldOutMessage: foldIgnoredOutMessage,
+      })(model, payload.message),
+    GotViewMessage: (payload: typeof Message.GotViewMessage.Type): UpdateReturn =>
+      Update.foldChild({
+        update: DemoMenu.update,
+        read: (state: State) => Option.some(state.viewMenu),
+        write: (state, next) => evo(state, { viewMenu: () => next }),
+        toParentMessage: (message) => Message.GotViewMessage({ message }),
+        foldOutMessage: foldCheckOutMessage,
+      })(model, payload.message),
+    GotProfilesMessage: (payload: typeof Message.GotProfilesMessage.Type): UpdateReturn =>
+      Update.foldChild({
+        update: DemoMenu.update,
+        read: (state: State) => Option.some(state.profilesMenu),
+        write: (state, next) => evo(state, { profilesMenu: () => next }),
+        toParentMessage: (message) => Message.GotProfilesMessage({ message }),
+        foldOutMessage: foldProfileOutMessage,
+      })(model, payload.message),
+    GotSubFileMessage: (payload: typeof Message.GotSubFileMessage.Type): UpdateReturn =>
+      Update.foldChild({
+        update: DemoMenu.update,
+        read: (state: State) => Option.some(state.subFileMenu),
+        write: (state, next) => evo(state, { subFileMenu: () => next }),
+        toParentMessage: (message) => Message.GotSubFileMessage({ message }),
+        foldOutMessage: foldIgnoredOutMessage,
+      })(model, payload.message),
+    GotSubEditMessage: (payload: typeof Message.GotSubEditMessage.Type): UpdateReturn =>
+      Update.foldChild({
+        update: DemoMenu.update,
+        read: (state: State) => Option.some(state.subEditMenu),
+        write: (state, next) => evo(state, { subEditMenu: () => next }),
+        toParentMessage: (message) => Message.GotSubEditMessage({ message }),
+        foldOutMessage: foldIgnoredOutMessage,
+      })(model, payload.message),
+    GotCheckViewMessage: (payload: typeof Message.GotCheckViewMessage.Type): UpdateReturn =>
+      Update.foldChild({
+        update: DemoMenu.update,
+        read: (state: State) => Option.some(state.checkViewMenu),
+        write: (state, next) => evo(state, { checkViewMenu: () => next }),
+        toParentMessage: (message) => Message.GotCheckViewMessage({ message }),
+        foldOutMessage: foldCheckOutMessage,
+      })(model, payload.message),
+    GotCheckFormatMessage: (payload: typeof Message.GotCheckFormatMessage.Type): UpdateReturn =>
+      Update.foldChild({
+        update: DemoMenu.update,
+        read: (state: State) => Option.some(state.checkFormatMenu),
+        write: (state, next) => evo(state, { checkFormatMenu: () => next }),
+        toParentMessage: (message) => Message.GotCheckFormatMessage({ message }),
+        foldOutMessage: foldFormatOutMessage,
+      })(model, payload.message),
+    GotRadioProfilesMessage: (payload: typeof Message.GotRadioProfilesMessage.Type): UpdateReturn =>
+      Update.foldChild({
+        update: DemoMenu.update,
+        read: (state: State) => Option.some(state.radioProfilesMenu),
+        write: (state, next) => evo(state, { radioProfilesMenu: () => next }),
+        toParentMessage: (message) => Message.GotRadioProfilesMessage({ message }),
+        foldOutMessage: foldProfileOutMessage,
+      })(model, payload.message),
+    GotRadioThemeMessage: (payload: typeof Message.GotRadioThemeMessage.Type): UpdateReturn =>
+      Update.foldChild({
+        update: DemoMenu.update,
+        read: (state: State) => Option.some(state.radioThemeMenu),
+        write: (state, next) => evo(state, { radioThemeMenu: () => next }),
+        toParentMessage: (message) => Message.GotRadioThemeMessage({ message }),
+        foldOutMessage: foldThemeOutMessage,
+      })(model, payload.message),
+    GotIconFileMessage: (payload: typeof Message.GotIconFileMessage.Type): UpdateReturn =>
+      Update.foldChild({
+        update: DemoMenu.update,
+        read: (state: State) => Option.some(state.iconFileMenu),
+        write: (state, next) => evo(state, { iconFileMenu: () => next }),
+        toParentMessage: (message) => Message.GotIconFileMessage({ message }),
+        foldOutMessage: foldIgnoredOutMessage,
+      })(model, payload.message),
+    GotIconMoreMessage: (payload: typeof Message.GotIconMoreMessage.Type): UpdateReturn =>
+      Update.foldChild({
+        update: DemoMenu.update,
+        read: (state: State) => Option.some(state.iconMoreMenu),
+        write: (state, next) => evo(state, { iconMoreMenu: () => next }),
+        toParentMessage: (message) => Message.GotIconMoreMessage({ message }),
+        foldOutMessage: foldIgnoredOutMessage,
+      })(model, payload.message),
+    GotRtlFileMessage: (payload: typeof Message.GotRtlFileMessage.Type): UpdateReturn =>
+      Update.foldChild({
+        update: DemoMenu.update,
+        read: (state: State) => Option.some(state.rtlFileMenu),
+        write: (state, next) => evo(state, { rtlFileMenu: () => next }),
+        toParentMessage: (message) => Message.GotRtlFileMessage({ message }),
+        foldOutMessage: foldIgnoredOutMessage,
+      })(model, payload.message),
+  }),
+  samples: [],
 })


### PR DESCRIPTION
## Parity audit — menubar (upstream `apps/v4/registry/bases/base/ui/menubar.tsx` vs foldcn)

| Upstream part | Before | After |
|---|---|---|
| Menubar bar (`cn-menubar flex items-center`, slot) | ✅ | ✅ |
| MenubarTrigger token string | ✅ | ✅ |
| MenubarContent tokens (`cn-menubar-content[-logical] cn-menu-target cn-menu-translucent`) | ✅ | ✅ |
| Content anchor (align=start, sideOffset=8) | ⚠️ gap 4 | ✅ gap 8 (`MENUBAR_ANCHOR`); alignOffset -4 has no anchor equivalent (documented) |
| MenubarGroup / Label (slot + labeled groups, separators) | ❌ no group passthrough | ✅ `itemGroupKey`/`groupToHeading`/`groupClass` + `menubar-group` slot |
| MenubarItem token | ✅ (menu-family convention: inline layout + `data-active:` twins for foldkit) | ✅ unchanged |
| MenubarItem `inset`/`variant` (data-inset/data-variant) | ❌ | ❌ primitive has no per-item attribute hook (documented; demo approximates with `pl-7`/`text-destructive`) |
| MenubarCheckboxItem (+ indicator) token strings | ❌ | ✅ verbatim constants |
| MenubarRadioGroup/Item (+ indicator) token strings | ❌ | ✅ verbatim constants (incl. upstream's no-opacity quirk on radio) |
| MenubarSub / SubTrigger / SubContent tokens | ❌ | ✅ verbatim constants (open-state via existing `cn-compat.css` data-open twins) |
| MenubarLabel alias | ❌ (`menubarHeadingClass` only) | ✅ `menubarLabelClass` alias |
| MenubarPortal | n/a | n/a — primitive portals the panel itself (documented) |
| Cross-menu ArrowLeft/Right, open-on-hover-next-trigger | ❌ | ❌ primitive ceiling — bug #7 stays OPEN (documented in module + demo notes) |
| Submenu / checkbox / radio item *behavior* | ❌ | ❌ primitive ceiling — demo covers with labeled groups + state-managed rows (menu closes on select; upstream keeps open) |
| Per-item data-slot (`menubar-item` etc.) | ❌ | ❌ no primitive hook (documented); panel-level slots stamped |
| `data-highlighted`/`focus:` item states | ⚠️ | ⚠️ by design — `data-active:` twins per `docs/deriving-from-base.md` mapping |

### Changed files
- `packages/registry/registry/default/ui/menubar.ts` — group support, missing token constants, anchor gap, gap docs
- `packages/web/src/demo/views/menubar.ts` — rewritten: all six upstream examples as live menus (demo / submenu / checkboxes / radio / icons+destructive / RTL) + behavior notes; 13 submodels with checkbox/radio state
- `packages/web/src/demo/assemble.ts` — dispatch new slice messages
- `docs/shadcn-base-parity-audit.md` — refresh stale menubar bullet

Constraints honored: no edits to `styles/style-*.css`, authored sources stay `cn-*` (+ verbatim upstream strings), built via `pnpm --filter @foldcn/registry run build`.

### Test plan
- `node packages/registry/scripts/resolve-styles.mjs` — 540 files, no leaked/unresolved tokens
- `pnpm --filter @foldcn/registry run build` — 68 items × 8 styles ✅
- `tsc --noEmit` (registry + web) ✅; `oxlint` on touched files ✅
- `vitest run` (web) — 11/11 ✅; full SSG `pnpm --filter @foldcn/web run build` ✅ (menubar page prerenders)
- Browser (agent-browser, dev server): opened every bar; File menu groups/separators/Share heading/disabled Incognito; keyboard Enter/Arrows/Home/End/typeahead; checkbox toggle both ways (✓ appears, separators hold); radio Andy→ status text updates; icons + red Delete; RTL bar; nova style switch re-renders cleanly
- Screenshots: full-page menubar render + cropped open-menu states (checked row, shortcuts right-aligned, disabled + inset rows)

### Intentional deviations (primitive ceiling, need @foldkit/ui work)
Bug #7 traversal, submenu kinds, checkbox/radio keep-open, per-item data-inset/data-variant/data-slot — all documented in code + demo behavior notes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Close menubar parity gaps with live interactive demo menus and upstream token exports
> - Replaces static text previews in the menubar demo with 13 live, independently interactive `Menu` submodels that support opening, keyboard navigation, typeahead, disabled items, grouping, headings, checkboxes, radio, icons, shortcuts, and RTL layout.
> - Adds registry exports for upstream menubar tokens: submenu trigger/content, checkbox-item/indicator, radio-item/indicator, and the label alias.
> - Changes default `MENUBAR_ANCHOR` bottom-start gap from 4 to 8 pixels.
> - Adds a `cn-compat.css` rule so elements carrying `cn-menu-translucent` render with an opaque popover background.
> - Risk: menus using the default `MENUBAR_ANCHOR` configuration now position with an 8px gap instead of 4px; verify this does not clip or overlap in constrained viewports. Submenu, checkbox, radio, destructive, inset, and per-item slot primitives remain unimplemented.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93da2ae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->