### PR TITLE
web: mobile docs nav as registry Sheet drawer

### DIFF
--- a/packages/web/src/init.ts
+++ b/packages/web/src/init.ts
@@ -5,6 +5,7 @@ import type * as Update from 'foldkit/update'
 import * as Tabs from '@foldkit/ui/tabs'
 
 import * as ToggleGroup from './generated/registry/ui/toggle-group'
+import * as Sheet from './generated/registry/ui/sheet'
 
 import * as Demo from './demo'
 import { parseRoute } from './route'
@@ -35,6 +36,7 @@ export const init = (url: Url.Url): InitReturn => {
       demo,
       installTabs,
       themeToggleGroup: ToggleGroup.init({ id: 'theme-toggle-group', type: 'single' }),
+      navSheet: Sheet.init({ id: 'nav-sheet' }),
       selectedPackageManager: 'pnpm',
       selectedStyle: 'default',
       expandedCodeBlocks: new Set<string>(),

--- a/packages/web/src/message.ts
+++ b/packages/web/src/message.ts
@@ -6,6 +6,7 @@ import { UrlRequest } from 'foldkit/navigation'
 import { Message as DemoMessage } from './demo'
 import { Message as InstallTabsMessage } from '@foldkit/ui/tabs'
 import { Message as ToggleGroupMessage } from './generated/registry/ui/toggle-group'
+import { Message as SheetMessage } from './generated/registry/ui/sheet'
 import { PackageManager, ResolvedTheme, ThemePreference } from './model'
 import { RegistryStyle } from './active-style'
 
@@ -29,6 +30,8 @@ export const Message = defineMessageUnion({
   GotInstallTabsMessage: { message: InstallTabsMessage },
   SelectedRegistryStyle: { style: RegistryStyle },
   GotThemeToggleGroupMessage: { message: ToggleGroupMessage },
+  ClickedOpenNavSheet: {},
+  GotNavSheetMessage: { message: SheetMessage },
   CompletedSavePackageManager: {},
   CompletedNavigateInternal: {},
   CompletedLoadExternal: {},

--- a/packages/web/src/model.ts
+++ b/packages/web/src/model.ts
@@ -2,6 +2,7 @@ import { Schema as S } from 'effect'
 import { Model as InstallTabsModel } from '@foldkit/ui/tabs'
 
 import { Model as ToggleGroupModel } from './generated/registry/ui/toggle-group'
+import { Model as SheetModel } from './generated/registry/ui/sheet'
 
 import { Model as DemoModelSchema } from './demo'
 import { RegistryStyle } from './active-style'
@@ -27,6 +28,9 @@ export const Model = S.Struct({
   /** The header's theme selector: a stateful ToggleGroup submodel whose
    *  selection mirrors `maybeThemePreference`. */
   themeToggleGroup: ToggleGroupModel,
+  /** The mobile docs nav drawer: a Sheet submodel (a Dialog state machine
+   *  owned by @foldkit/ui via the Sheet re-export), not scattered booleans. */
+  navSheet: SheetModel,
   selectedPackageManager: PackageManager,
   /** The registry style applied to the live demo previews (see active-style.ts). */
   selectedStyle: RegistryStyle,

--- a/packages/web/src/page/chrome.ts
+++ b/packages/web/src/page/chrome.ts
@@ -10,7 +10,8 @@ import { badge } from '../generated/registry/ui/badge'
 import { separator } from '../generated/registry/ui/separator'
 import { styledViewInputs as tabsStyledViewInputs } from '../generated/registry/ui/tabs'
 import * as toggleGroup from '../generated/registry/ui/toggle-group'
-import { ArrowRight, Computer, Moon, Sun } from 'lucide'
+import * as Sheet from '../generated/registry/ui/sheet'
+import { ArrowRight, Computer, Menu, Moon, Sun } from 'lucide'
 
 import { Message } from '../message'
 import type { Message as AppMessage } from '../message'
@@ -63,6 +64,8 @@ export const themeSelector = (
     toParentMessage: (message) => Message.GotThemeToggleGroupMessage({ message }),
   })
 
+const isDocsRoute = (routeTag: string): boolean => routeTag === 'Components' || routeTag === 'Item'
+
 export const headerView = (
   h: HtmlBuilder<AppMessage>,
   themeToggle: Model['themeToggleGroup'],
@@ -70,6 +73,7 @@ export const headerView = (
   // memoized VNode must rebuild for the new tree. Unused by design.
   // oxlint-disable-next-line typescript/no-unused-vars
   _style: RegistryStyle,
+  routeTag: string,
 ): Html => {
   return h.header(
     [h.Class('py-4 font-mono')],
@@ -81,19 +85,39 @@ export const headerView = (
           ),
         ],
         [
-          h.a(
-            [h.Href('/'), h.Class('flex items-center gap-2 font-semibold tracking-tight')],
+          h.div(
+            [h.Class('flex items-center gap-1')],
             [
-              h.span(
+              ...(isDocsRoute(routeTag)
+                ? [
+                    h.button(
+                      [
+                        h.Type('button'),
+                        h.OnClick(Message.ClickedOpenNavSheet()),
+                        h.AriaLabel('Open docs navigation'),
+                        h.Class(
+                          'inline-flex size-9 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground lg:hidden',
+                        ),
+                      ],
+                      [icon(h, Menu, 'size-5')],
+                    ),
+                  ]
+                : []),
+              h.a(
+                [h.Href('/'), h.Class('flex items-center gap-2 font-semibold tracking-tight')],
                 [
-                  h.Class(
-                    'flex size-5 items-center justify-center rounded bg-foreground text-background',
+                  h.span(
+                    [
+                      h.Class(
+                        'flex size-5 items-center justify-center rounded bg-foreground text-background',
+                      ),
+                    ],
+                    [h.span([h.Class('text-[11px] leading-none font-black')], ['F'])],
                   ),
+                  h.span([], ['foldcn']),
+                  betaBadge(h),
                 ],
-                [h.span([h.Class('text-[11px] leading-none font-black')], ['F'])],
               ),
-              h.span([], ['foldcn']),
-              betaBadge(h),
             ],
           ),
           h.div(
@@ -143,13 +167,11 @@ const parityLegendBadge = (status: ParityStatus, h: HtmlBuilder<AppMessage>): Ht
     h,
   )
 
-export const sidebarView = (
+export const docsNavContent = (
   h: HtmlBuilder<AppMessage>,
   routeTag: string,
   routeName: string | undefined,
-  // oxlint-disable-next-line typescript/no-unused-vars
-  _style: RegistryStyle,
-): Html => {
+): ReadonlyArray<Html> => {
   const componentsGroup = categoryGroups.find((g) => g.category === 'Components')
   const components = componentsGroup?.items ?? []
   const counts = {
@@ -158,7 +180,140 @@ export const sidebarView = (
     'foldcn-only': components.filter((i) => parityStatus(i.name) === 'foldcn-only').length,
   } as const
 
-  return h.aside(
+  return [
+    h.div(
+      [h.Class('mb-6 rounded-lg border border-border bg-muted/20 px-3 py-3')],
+      [
+        h.p(
+          [h.Class('text-xs font-semibold tracking-wide text-foreground')],
+          ['Parity with shadcn/ui'],
+        ),
+        h.ul(
+          [h.Class('mt-2 flex flex-col gap-2')],
+          [
+            h.li(
+              [h.Class('flex items-center justify-between gap-2')],
+              [
+                parityLegendBadge('full', h),
+                h.span(
+                  [h.Class('text-xs tabular-nums text-muted-foreground')],
+                  [String(counts.full)],
+                ),
+              ],
+            ),
+            h.li(
+              [h.Class('flex items-center justify-between gap-2')],
+              [
+                parityLegendBadge('diverged', h),
+                h.span(
+                  [h.Class('text-xs tabular-nums text-muted-foreground')],
+                  [String(counts.diverged)],
+                ),
+              ],
+            ),
+            h.li(
+              [h.Class('flex items-center justify-between gap-2')],
+              [
+                parityLegendBadge('foldcn-only', h),
+                h.span(
+                  [h.Class('text-xs tabular-nums text-muted-foreground')],
+                  [String(counts['foldcn-only'])],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+    ),
+    h.nav(
+      [h.Class('flex flex-col gap-6'), h.AriaLabel('Components')],
+      categoryGroups.map((group) => {
+        const sortedItems = [...group.items].sort((a, b) => a.title.localeCompare(b.title))
+        const isComponentsGroup = group.category === 'Components'
+        return h.div(
+          [h.Class('flex flex-col gap-2')],
+          [
+            h.h3(
+              [h.Class('px-2 text-xs font-semibold tracking-wide text-foreground')],
+              [group.label],
+            ),
+            h.ul(
+              [h.Class('flex flex-col gap-0.5')],
+              sortedItems.map((item) => {
+                const isActive = routeTag === 'Item' && routeName === item.name
+                const status: ParityStatus | null = isComponentsGroup
+                  ? parityStatus(item.name)
+                  : null
+                const badgeTitle =
+                  status === null
+                    ? ''
+                    : status === 'diverged'
+                      ? (gapsForItem(item.name)?.[0] ?? parityTitle.diverged)
+                      : parityTitleForItem(item.name)
+                return h.li(
+                  [],
+                  [
+                    h.a(
+                      [
+                        h.Href(`/docs/${item.name}`),
+                        h.Class(
+                          cn(
+                            'flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',
+                            isActive
+                              ? 'bg-muted font-medium text-foreground'
+                              : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+                          ),
+                        ),
+                        ...(isActive ? [h.AriaCurrent('page')] : []),
+                        ...(status !== null
+                          ? [h.Title(badgeTitle), h.AriaLabel(`${item.title} — ${badgeTitle}`)]
+                          : []),
+                      ],
+                      [
+                        h.span([h.Class('truncate')], [item.title]),
+                        status !== null ? parityBadge(status, h) : h.span([], []),
+                      ],
+                    ),
+                  ],
+                )
+              }),
+            ),
+          ],
+        )
+      }),
+    ),
+    h.div(
+      [h.Class('mt-6 rounded-lg border border-border bg-muted/20 px-3 py-3')],
+      [
+        h.p([h.Class('text-xs font-medium text-foreground')], ['Missing something?']),
+        h.p(
+          [h.Class('mt-1 text-xs leading-relaxed text-muted-foreground')],
+          ['Request a component'],
+        ),
+        h.a(
+          [
+            h.Href(requestComponentUrl()),
+            h.Target('_blank'),
+            h.Rel('noopener noreferrer'),
+            h.Class(
+              'mt-2 inline-flex items-center justify-center rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-muted',
+            ),
+          ],
+          ['Request a component →'],
+        ),
+      ],
+    ),
+  ]
+}
+
+export const sidebarView = (
+  h: HtmlBuilder<AppMessage>,
+  routeTag: string,
+  routeName: string | undefined,
+  // oxlint-disable-next-line typescript/no-unused-vars
+  _style: RegistryStyle,
+): Html =>
+  h.aside(
     [h.Class('hidden w-[220px] shrink-0 font-mono lg:block'), h.AriaLabel('Sidebar')],
     [
       h.div(
@@ -167,137 +322,37 @@ export const sidebarView = (
             'sticky top-10 h-[calc(100vh-2.5rem)] overflow-y-auto overflow-x-visible border-r border-border py-6 pr-4',
           ),
         ],
-        [
-          h.div(
-            [h.Class('mb-6 rounded-lg border border-border bg-muted/20 px-3 py-3')],
-            [
-              h.p(
-                [h.Class('text-xs font-semibold tracking-wide text-foreground')],
-                ['Parity with shadcn/ui'],
-              ),
-              h.ul(
-                [h.Class('mt-2 flex flex-col gap-2')],
-                [
-                  h.li(
-                    [h.Class('flex items-center justify-between gap-2')],
-                    [
-                      parityLegendBadge('full', h),
-                      h.span(
-                        [h.Class('text-xs tabular-nums text-muted-foreground')],
-                        [String(counts.full)],
-                      ),
-                    ],
-                  ),
-                  h.li(
-                    [h.Class('flex items-center justify-between gap-2')],
-                    [
-                      parityLegendBadge('diverged', h),
-                      h.span(
-                        [h.Class('text-xs tabular-nums text-muted-foreground')],
-                        [String(counts.diverged)],
-                      ),
-                    ],
-                  ),
-                  h.li(
-                    [h.Class('flex items-center justify-between gap-2')],
-                    [
-                      parityLegendBadge('foldcn-only', h),
-                      h.span(
-                        [h.Class('text-xs tabular-nums text-muted-foreground')],
-                        [String(counts['foldcn-only'])],
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ],
-          ),
-          h.nav(
-            [h.Class('flex flex-col gap-6'), h.AriaLabel('Components')],
-            categoryGroups.map((group) => {
-              const sortedItems = [...group.items].sort((a, b) => a.title.localeCompare(b.title))
-              const isComponentsGroup = group.category === 'Components'
-              return h.div(
-                [h.Class('flex flex-col gap-2')],
-                [
-                  h.h3(
-                    [h.Class('px-2 text-xs font-semibold tracking-wide text-foreground')],
-                    [group.label],
-                  ),
-                  h.ul(
-                    [h.Class('flex flex-col gap-0.5')],
-                    sortedItems.map((item) => {
-                      const isActive = routeTag === 'Item' && routeName === item.name
-                      const status: ParityStatus | null = isComponentsGroup
-                        ? parityStatus(item.name)
-                        : null
-                      const badgeTitle =
-                        status === null
-                          ? ''
-                          : status === 'diverged'
-                            ? (gapsForItem(item.name)?.[0] ?? parityTitle.diverged)
-                            : parityTitleForItem(item.name)
-                      return h.li(
-                        [],
-                        [
-                          h.a(
-                            [
-                              h.Href(`/docs/${item.name}`),
-                              h.Class(
-                                cn(
-                                  'flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',
-                                  isActive
-                                    ? 'bg-muted font-medium text-foreground'
-                                    : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
-                                ),
-                              ),
-                              ...(isActive ? [h.AriaCurrent('page')] : []),
-                              ...(status !== null
-                                ? [
-                                    h.Title(badgeTitle),
-                                    h.AriaLabel(`${item.title} — ${badgeTitle}`),
-                                  ]
-                                : []),
-                            ],
-                            [
-                              h.span([h.Class('truncate')], [item.title]),
-                              status !== null ? parityBadge(status, h) : h.span([], []),
-                            ],
-                          ),
-                        ],
-                      )
-                    }),
-                  ),
-                ],
-              )
-            }),
-          ),
-          h.div(
-            [h.Class('mt-6 rounded-lg border border-border bg-muted/20 px-3 py-3')],
-            [
-              h.p([h.Class('text-xs font-medium text-foreground')], ['Missing something?']),
-              h.p(
-                [h.Class('mt-1 text-xs leading-relaxed text-muted-foreground')],
-                ['Request a component'],
-              ),
-              h.a(
-                [
-                  h.Href(requestComponentUrl()),
-                  h.Target('_blank'),
-                  h.Rel('noopener noreferrer'),
-                  h.Class(
-                    'mt-2 inline-flex items-center justify-center rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-muted',
-                  ),
-                ],
-                ['Request a component →'],
-              ),
-            ],
-          ),
-        ],
+        docsNavContent(h, routeTag, routeName),
       ),
     ],
   )
-}
+
+export const navSheetView = (
+  h: HtmlBuilder<AppMessage>,
+  navSheet: Model['navSheet'],
+  routeTag: string,
+  routeName: string | undefined,
+): Html =>
+  h.submodel({
+    slotId: navSheet.id,
+    model: navSheet,
+    view: Sheet.view,
+    viewInputs: Sheet.styledViewInputs(
+      {
+        side: 'left',
+        content: ({ title }, h) => [
+          Sheet.header(
+            {},
+            [Sheet.title({ attributes: title, className: 'sr-only' }, ['Docs navigation'], h)],
+            h,
+          ),
+          h.div([h.Class('overflow-y-auto px-2 pb-6')], docsNavContent(h, routeTag, routeName)),
+        ],
+      },
+      h,
+    ),
+    toParentMessage: (message) => Message.GotNavSheetMessage({ message }),
+  })
 
 export const footerView = (
   h: HtmlBuilder<AppMessage>,

--- a/packages/web/src/update.ts
+++ b/packages/web/src/update.ts
@@ -12,6 +12,7 @@ import { Message } from './message'
 import type { Message as AppMessage } from './message'
 import { Model, PackageManager, ResolvedTheme, ThemePreference } from './model'
 import * as ToggleGroup from './generated/registry/ui/toggle-group'
+import * as Sheet from './generated/registry/ui/sheet'
 
 export const THEME_STORAGE_KEY = 'foldcn-theme'
 export const PACKAGE_MANAGER_STORAGE_KEY = 'foldcn-package-manager'
@@ -240,6 +241,14 @@ const foldInstallTabs = (model: Model, message: Tabs.Message): UpdateReturn => {
   }
 }
 
+const foldNavSheet = (model: Model, message: Sheet.Message): UpdateReturn => {
+  const { model: next, commands = [] } = Sheet.update(model.navSheet, message)
+  return {
+    model: evo(model, { navSheet: () => next }),
+    commands: Command.mapMessages(commands, (m) => Message.GotNavSheetMessage({ message: m })),
+  }
+}
+
 export const update = (model: Model, message: AppMessage): UpdateReturn =>
   M.value(message).pipe(
     withUpdateReturn,
@@ -255,13 +264,29 @@ export const update = (model: Model, message: AppMessage): UpdateReturn =>
             External: ({ href }) => ({ model, commands: [LoadExternal({ href })] }),
           }),
         ),
-      ChangedUrl: ({ url }) => ({
-        model: evo(model, { route: () => parseRoute(url) }),
-        commands: [ScrollToTop()],
-      }),
+      ChangedUrl: ({ url }) => {
+        const { model: nextNavSheet, commands: navCommands = [] } = Sheet.close(model.navSheet)
+        return {
+          model: evo(model, { route: () => parseRoute(url), navSheet: () => nextNavSheet }),
+          commands: [
+            ScrollToTop(),
+            ...Command.mapMessages(navCommands, (m) => Message.GotNavSheetMessage({ message: m })),
+          ],
+        }
+      },
       GotDemoMessage: ({ message }) => foldDemo(model, message),
       GotInstallTabsMessage: ({ message }) => foldInstallTabs(model, message),
       GotThemeToggleGroupMessage: ({ message }) => foldThemeToggleGroup(model, message),
+      ClickedOpenNavSheet: () => {
+        const { model: next, commands = [] } = Sheet.open(model.navSheet)
+        return {
+          model: evo(model, { navSheet: () => next }),
+          commands: Command.mapMessages(commands, (m) =>
+            Message.GotNavSheetMessage({ message: m }),
+          ),
+        }
+      },
+      GotNavSheetMessage: ({ message }) => foldNavSheet(model, message),
 
       SelectedThemePreference: ({ preference }) => applyThemePreference(model, preference),
       ChangedSystemTheme: ({ theme }) =>

--- a/packages/web/src/view.ts
+++ b/packages/web/src/view.ts
@@ -2,7 +2,7 @@ import type { Document, Html, HtmlBuilder } from 'foldkit/html'
 import { createLazy } from 'foldkit/html'
 
 import { pageUrlFor, seoForPath } from './seo'
-import { footerView, headerView } from './page/chrome'
+import { footerView, headerView, navSheetView } from './page/chrome'
 import { activeRegistryStyle } from './active-style'
 import type { RegistryStyle } from './active-style'
 import { componentsIndexView } from './page/components'
@@ -32,10 +32,13 @@ const siteHeader = (
   h: HtmlBuilder<Message>,
   style: RegistryStyle,
   themeToggle: Model['themeToggleGroup'],
-): Html => headerView(h, themeToggle, style)
+  routeTag: string,
+): Html => headerView(h, themeToggle, style, routeTag)
 
 export const view = (model: Model, h: HtmlBuilder<Message>): Document => {
   const path = pathOf(model.route)
+  const routeTag = model.route._tag
+  const routeName = routeTag === 'Item' ? model.route.name : undefined
   return {
     title: seoForPath(path).title,
     canonical: pageUrlFor(path),
@@ -43,7 +46,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => {
     body: h.div(
       [h.Class('flex min-h-svh flex-col bg-background text-foreground')],
       [
-        siteHeaderLazy(siteHeader, [h, activeRegistryStyle(), model.themeToggleGroup]),
+        siteHeaderLazy(siteHeader, [h, activeRegistryStyle(), model.themeToggleGroup, routeTag]),
         h.main(
           [h.Class('flex-1')],
           [
@@ -56,6 +59,7 @@ export const view = (model: Model, h: HtmlBuilder<Message>): Document => {
           ],
         ),
         siteFooterLazy(footerView, [h, activeRegistryStyle()]),
+        navSheetView(h, model.navSheet, routeTag, routeName),
       ],
     ),
   }


### PR DESCRIPTION
## Problem

The docs sidebar was `hidden lg:block` with no mobile alternative. Below the `lg` breakpoint docs pages had zero navigation.

## What changed

Dogfoods the registry Sheet submodel for the docs sidebar on viewports below `lg`. Desktop keeps the sticky aside untouched.

- `model.ts`: new `navSheet: SheetModel` field. State is the Dialog state machine owned by `@foldkit/ui`, not scattered booleans.
- `message.ts`: new `ClickedOpenNavSheet` and `GotNavSheetMessage`.
- `init.ts`: deterministic `Sheet.init({ id: 'nav-sheet' })`, SSR safe.
- `update.ts`: new `foldNavSheet` following the existing child fold pattern. `ChangedUrl` also runs `Sheet.close` so the drawer closes on navigation.
- `page/chrome.ts`: extracted `docsNavContent` as the single nav owner shared by the desktop aside and the drawer. `headerView` takes the route tag and renders a docs-only `lg:hidden` hamburger with the Menu icon. New `navSheetView` mounts the drawer via `Sheet.styledViewInputs` with `side: 'left'` and an sr-only title.
- `view.ts`: header memo slot keyed on route tag. Drawer mounts outside the lazy slots so open state re-renders.

## Why Sheet over SidebarProvider

SidebarProvider would drag in cookie persistence, media query subscriptions, and collapse choreography for a simple link list. Sheet is the smaller correct primitive. Desktop rail and mobile drawer stay one shared content callback with zero duplication by construction.

## Verification

- `tsc --noEmit` clean for `@foldcn/web`.
- `vitest run` passes 18 of 18.
- Registry build succeeds across all 8 styles.
- Drove real Chrome via agent-browser at 1440px and 390px. Desktop shows the sidebar with no hamburger. Mobile shows the hamburger with full width content. Clicking it opens the left drawer with the parity card and component list. Screenshots were captured for desktop, mobile closed, and mobile drawer open.

## Follow-ups

- Drawer has no visible close button. Overlay and Escape close it today. Open to adding an explicit control if wanted.