### PR TITLE
command: add stateful palette and composed CommandDialog

### DIFF
--- a/docs/command-composition.md
+++ b/docs/command-composition.md
@@ -1,0 +1,133 @@
+# Command and CommandDialog guide
+
+This guide describes the implementation in this checkout. The changes are pending review; the published registry and showcase may still contain the previous implementation.
+
+## Install and import
+
+Once this version is published, install the Command registry item:
+
+```sh
+npx shadcn@latest add @foldcn/command
+```
+
+The item includes `command.ts` and `command-score.ts`, with Dialog, InputGroup, icons, and utilities as registry dependencies. CommandDialog is exported from the same module:
+
+```ts
+import * as Command from '@/components/ui/command'
+```
+
+`Command.Model`, `Command.Message`, `Command.update`, and `Command.view` provide the stateful inline palette. `Command.CommandDialog` owns a palette and its Dialog lifecycle. The separate `Command.Command` function and its `input`, `list`, `group`, `item`, `empty`, `separator`, and `shortcut` properties are low-level markup builders; using those builders alone does not wire interaction.
+
+The stateful view renders each row through `Command.item`. That builder owns option semantics, command styles, and selected/disabled/checked attributes. Its `attributes` option accepts IDs and event handlers; the stateful view supplies navigation and selection handlers.
+
+## Wire an inline palette
+
+Add `Command.Model` to your parent model schema and initialize it with a unique DOM-safe ID:
+
+```ts
+const command = Command.init({ id: 'app-command' })
+
+const items: ReadonlyArray<Command.Item> = [
+  { value: 'calendar', label: 'Calendar', keywords: ['schedule', 'events'] },
+  { value: 'billing', label: 'Billing', keywords: ['payment'], shortcut: '⌘B' },
+  { value: 'calculator', label: 'Calculator', isDisabled: true },
+]
+```
+
+Define a parent message carrying `Command.Message`. Use `Update.foldChild` to read and write the child model, call `Command.update`, map child messages, and handle out-messages. Preserve returned commands: keyboard navigation uses them to scroll the active item into view.
+
+Render the child through `h.submodel`. In this example, `Message.GotCommandMessage` is your parent message constructor:
+
+```ts
+h.submodel({
+  slotId: model.command.id,
+  model: model.command,
+  view: Command.view,
+  viewInputs: { items, label: 'Search commands', loop: true },
+  toParentMessage: (message) => Message.GotCommandMessage({ message }),
+})
+```
+
+Handle the `Selected` out-message to run the action identified by `value`. Selection preserves the query and leaves the inline list visible. `SearchChanged` reports input changes; `ValueChanged` reports explicit keyboard or pointer activation. A search change clears the stored active value, and the view falls back to the first enabled result. That fallback does not emit `ValueChanged`.
+
+The complete parent wiring is in `packages/web/src/demo/views/command.ts`. Its `slice` and `fields` belong to the showcase harness; applications can use their own parent model and update function.
+
+## Configure items and filtering
+
+Each item needs a unique, stable `value`. The optional `label` defaults to that value. `content` replaces the rendered label with custom HTML, while filtering still uses `label ?? value`. Keep a textual label when supplying icons or other custom content.
+
+The default filter uses the cmdk scoring algorithm adapted in `command-score.ts`. It trims the query, label, and keywords, matches fuzzy subsequences and keyword aliases, and sorts matching items by descending score. Equal scores preserve declaration order. With an empty query, items retain declaration order within their groups.
+
+Use `group` on items and `groups: [{ value, heading }]` in view inputs to label sections. Group members stay contiguous; the highest-ranked member determines its group's position. Declared groups with no results remain mounted but hidden. Separators between sections appear only when the query is empty.
+
+The following options change rendering or filtering:
+
+- `filter(labelOrValue, search, keywords)` supplies a custom numeric score. Positive scores match; zero or negative scores are excluded unless forced to render.
+- `shouldFilter: false` bypasses filtering and ranking. The application supplies results, which are still grouped together.
+- Item `forceMount: true` retains that item regardless of its score. Group `forceMount: true` retains all its items and keeps the group visible when empty.
+- `isDisabled: true` keeps a matching item visible but excludes it from activation and selection.
+- `isChecked: true` displays a check indicator. It does not create checkbox state or toggle the item.
+- `shortcut` displays a hint; it does not register a hotkey and replaces the check indicator.
+- `loading: true` adds a progressbar row with `loadingText`, defaulting to “Loading commands...”. Loading state and asynchronous fetching belong to the application.
+- `emptyText` defaults to “No results found.” The empty row appears when there are no results, including while loading. Disabled results count as results.
+- `label`, `placeholder`, and `className` configure the accessible name, input placeholder, and palette container.
+
+## Configure navigation
+
+Focus stays in the search input. The list uses `role="listbox"`, items use `role="option"`, and `aria-activedescendant` identifies the active item.
+
+- Arrow Up and Arrow Down move through enabled results. Navigation clamps at the ends unless `loop: true` is set.
+- Home and End select the first and last enabled results. Meta+Arrow Up/Down also jumps to an edge.
+- Alt+Arrow Up/Down moves to an adjacent group, falling back to ordinary navigation when no adjacent group exists.
+- Ctrl+N/J and Ctrl+P/K move down and up by default. Set `vimBindings: false` to disable these bindings.
+- Enter emits `Selected` for the active enabled item. IME composition events are ignored.
+- Pointer movement activates enabled items, except for touch input. `disablePointerSelection: true` disables hover activation; clicking still selects.
+
+The mounted palette measures its list content and exposes `--cmdk-list-height` for CSS animation. It emits `cmdk-*` attributes used by the upstream group styles.
+
+## Add a dialog
+
+Use one `Command.CommandDialog.Model` in the parent schema and one parent message carrying `Command.CommandDialog.Message`:
+
+```ts
+const commandDialog = Command.CommandDialog.init({
+  id: 'app-command-dialog',
+  closeOnSelect: true,
+  resetOnOpen: true,
+})
+```
+
+Fold child updates through `Command.CommandDialog.update`, and render `Command.CommandDialog.view` through `h.submodel`. Pass the same item and filtering options as the inline view. The dialog also accepts `title`, `description`, `showCloseButton`, and `panelClass`. Its title and description provide accessible context and are visually hidden. The close button is omitted by default.
+
+Call `Command.CommandDialog.open(model.commandDialog)` or `.close(model.commandDialog)` from the parent update. Store the returned model and map the returned commands to the parent message. The underlying Dialog handles initial input focus, modal focus management, dismissal, animation, and focus restoration.
+
+By default, `closeOnSelect` and `resetOnOpen` are both false: selection leaves the dialog open, and reopening preserves the query. With `closeOnSelect: true`, selection closes the dialog and emits `Selected`. With `resetOnOpen: true`, opening a closed dialog clears its query and active value. `isAnimated` defaults to true.
+
+The wrapper forwards Command out-messages and Dialog `Opened`/`Closed` events. Closing through selection returns `Selected`; callers should not require a separate `Closed` out-message for that path.
+
+Register global shortcuts in the application. The showcase scopes ⌘K/Ctrl+K to `/docs/command` and disables Vim bindings inside its dialog so Ctrl+K can toggle it. Inline Ctrl+K remains an upward-navigation binding. Item shortcut hints do not execute actions.
+
+## Check the showcase
+
+Start `pnpm --filter @foldcn/web dev` and open `/docs/command` on the local server. The inline example keeps its search after selection. The dialog example opts into closing after selection and resetting on reopen.
+
+1. Search for `clndr` inline and press Enter. Calendar runs, and the inline query remains.
+2. Clear the search and use arrow keys, Home, and End. Navigation skips Calculator.
+3. Open the command palette and search for `payment`. Billing is the matching action.
+4. Select Billing. The dialog closes and the run counter increments.
+5. Reopen the dialog. Its query is empty. Hover over and click an enabled result to run it.
+6. Search for an unmatched query. The empty message appears, and Enter runs nothing.
+7. Press Escape to dismiss the dialog, then check the application shortcut and restored focus.
+
+The browser regression script is `packages/web/scripts/verify-command-composition.mjs`. From the local page's browser console:
+
+```js
+const { verifyCommandComposition } = await import('/scripts/verify-command-composition.mjs')
+await verifyCommandComposition()
+```
+
+These are verification instructions, not a claim that browser checks have passed for every style. Unit coverage lives in `packages/web/src/command-behavior.test.ts`.
+
+## Scope relative to cmdk
+
+This is a data-driven Foldkit API, not a drop-in React cmdk API. Items and groups come from view inputs rather than child registration. CommandDialog composes Foldkit Dialog. Nested command pages, asynchronous requests, application actions, and global shortcuts remain application-owned. The implementation does not establish complete behavioral or visual parity with cmdk.

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -13,11 +13,11 @@ npx shadcn@latest add @foldcn/button @foldcn/dialog
 
 ## Component families
 
-| Family                   | Pattern                                                       | When                                                                                                                                                                 |
-| ------------------------ | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Helpers**              | Stateless builder (`ViewConfig + builder → Html`)             | Simple controls: button, input, switch, checkbox                                                                                                                     |
-| **Submodels**            | Stateful (`Model + Message + update + view` via `h.submodel`) | Focus/open/selection: dialog, popover, menu, calendar, toast. Some re-export `@foldkit/ui`, others (toggle, accordion, collapsible, resizable) are authored in place |
-| **Presentational ports** | Static markup, no state machine                               | Layout matching shadcn: badge, separator, card, table, sidebar                                                                                                       |
+| Family                   | Pattern                                                       | When                                                                                                                                                                          |
+| ------------------------ | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Helpers**              | Stateless builder (`ViewConfig + builder → Html`)             | Simple controls: button, input, switch, checkbox                                                                                                                              |
+| **Submodels**            | Stateful (`Model + Message + update + view` via `h.submodel`) | Focus/open/selection: dialog, popover, menu, calendar, toast. Some re-export `@foldkit/ui`, others (toggle, accordion, collapsible, resizable, command) are authored in place |
+| **Presentational ports** | Static markup, no state machine                               | Layout matching shadcn: badge, separator, card, table, sidebar                                                                                                                |
 
 If it manages focus, open state, or selection → submodel. If purely visual → helper or presentational.
 
@@ -33,6 +33,8 @@ Tokens a style does not define strip to nothing during resolve (matching upstrea
 ## Style system
 
 Vendored CSS (`registry/styles/style-*.css`) is byte-identical to upstream — never edit. Hand-written Foldkit deltas live in `registry/default/style/cn-compat.css` (e.g. `aria-disabled`/`data-disabled` twins, `cn-font-heading` bridge, `no-scrollbar`). Resolve keeps them separate; syncing stays a plain `diff`. See ADR-015 and `registry/styles/README.md`.
+
+Command owns its query and active value; CommandDialog owns both Command and Dialog submodels. Items, actions, and global shortcuts belong to the caller. See [Command and CommandDialog](command-composition.md). The resolver preserves `cmdk-*` selectors because the stateful view emits those attributes.
 
 ## Demo harness
 

--- a/docs/shadcn-base-parity-audit.md
+++ b/docs/shadcn-base-parity-audit.md
@@ -7,7 +7,7 @@
 > against the **pre-migration legacy port** and are kept for the functional-gap analysis
 > only; class-material diffs (radius/surface/ring columns) are resolved as of this
 > branch. Primitive-level gaps (menus without submenu/checkbox kinds, static sidebar,
-> presentational command, click-vs-hover popover family) still stand.
+> click-vs-hover popover family) still stand. Command has a later update below.
 >
 > **Functional-gap update (2026-08-22):** gaps #1–#4 below are FIXED:
 > #1 button disabled → `aria-disabled:`/`data-disabled:` twins added in `packages/registry/registry/default/style/cn-compat.css` (button block);
@@ -66,11 +66,11 @@ Beyond styling, several foldcn components are missing their **defining behaviors
 5. **hover-card — click-toggled, not hover.** It reuses the Popover submodel; there is no hover-intent delay/grace model. Trigger semantics are the component's defining behavior.
 6. **context-menu — not a context menu.** Opens on activation at a fixed anchor; no right-click/pointer-position anchoring.
 7. **menubar — no menubar behavior.** Each trigger is an independent Menu bundle; no ArrowLeft/Right traversal, no open-on-hover-of-next-trigger.
-8. **command — pure markup.** No filtering, arrow-key nav, Enter-to-select, roving tabindex, or Dialog wrapper; `[cmdk-group-heading]` selectors in its classes match nothing.
+8. **command — implemented in the current review branch (2026-09-05).** Stateful Command provides fuzzy ranking, keyword aliases, groups, disabled items, and keyboard/pointer selection. CommandDialog composes Foldkit Dialog with configurable close/reset behavior. The view emits `cmdk-group-heading`, and the resolver preserves its selectors. See the [Command and CommandDialog guide](command-composition.md). Publication and full browser/visual parity verification remain pending.
 9. **toast/sonner — no swipe-to-dismiss, no stack expansion** (index-based scale/peek choreography absent); hover-pause restarts the _full_ duration on resume. foldcn emits literal `cn-toast` but defines no such rule in its CSS (inert class).
 10. **sidebar — interactive shell with one remaining gap.** Collapse modes (`offcanvas|icon|none`), side/variant props, mobile Sheet path, ⌘/Ctrl+B shortcut, rail, all 20+ parts (`groupAction/groupContent/menuAction/menuBadge/menuSkeleton/menuSub*`, `input`, RTL flip), and shared collapsed-mode menu-button tooltip composition are now ported. Remaining: desktop cookie hydration still needs its wrapper marker when the initial DOM must be corrected before model hydration.
 11. **avatar — no image loading/error fallback chain** (stateless `<img>`; base swaps to Fallback automatically).
-12. **Inert/dead classes:** `peer-disabled:*` on input/textarea labels (no `.peer` sibling exists); command's cmdk selectors (above).
+12. **Inert/dead classes:** `peer-disabled:*` on input/textarea labels (no `.peer` sibling exists). Command now emits its cmdk attributes and preserves their selectors.
 
 > **2026-08-26 sidebar:** the static-paint bucket for sidebar is closed. The collapsible app shell, keyboard shortcut, mobile sheet, rail, and the `menu* / group* / input` sub-parts were added to `packages/registry/registry/default/ui/sidebar.ts`, and the demo at `packages/web/src/demo/views/sidebar.ts` now embeds the provider submodel, exercises `offcanvas|icon|none × left|right × sidebar|floating|inset`, and lifts the breakpoint/keyboard subscriptions.
 
@@ -99,7 +99,7 @@ Beyond styling, several foldcn components are missing their **defining behaviors
 - **context-menu — MAJOR.** Same gaps as menu + no pointer anchoring (bug #6).
 - **menubar — MAJOR.** Bar of independent live menus (per-menu open/keyboard/typeahead/disabled/groups all work; anchor gap 8 = upstream sideOffset; group + checkbox/radio/sub token constants ported, demo covers every upstream example interactively). Still no cross-menu keyboard model (bug #7 — OPEN); submenu/checkbox/radio/destructive/inset item kinds need primitive work (demo uses labeled groups + state-managed check/radio rows).
 - **combobox — MAJOR.** Parent-owned filtering; no chips UI for multi-select, no clear button, no Empty row; panel metrics differ.
-- **command — MAJOR.** Presentational only (bug #8); item selection `bg-accent` vs base `bg-muted`.
+- **command — updated, parity not re-audited.** See #8 for the stateful implementation. The API uses Foldkit models and item arrays; it does not expose React child registration.
 
 ### Overlays
 

--- a/packages/registry/registry/default/style/cn-compat.css
+++ b/packages/registry/registry/default/style/cn-compat.css
@@ -261,3 +261,16 @@
 .cn-menu-translucent {
   @apply bg-popover;
 }
+
+/* CommandDialog composes the native Dialog host with shadcn's command panel. */
+.cn-command-dialog {
+  @apply top-1/3 translate-y-0 overflow-hidden p-0;
+}
+
+.cn-command-dialog-header {
+  @apply sr-only;
+}
+
+.cn-command-item-indicator {
+  @apply size-4 shrink-0 ml-auto opacity-0 group-has-data-[slot=command-shortcut]/command-item:hidden group-data-[checked=true]/command-item:opacity-100;
+}

--- a/packages/registry/registry/default/ui/command-score.ts
+++ b/packages/registry/registry/default/ui/command-score.ts
@@ -1,0 +1,192 @@
+/**
+ * Adapted from dip/cmdk command-score.ts, commit dd2250ed608443e8f32bafc5fa2d1d07a3746aa3.
+ * Changes: explicit types, block-scoped locals, Map memoization, readonly aliases.
+ * MIT License
+ * Copyright (c) 2022 Paco Coursey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+// The scores are arranged so that a continuous match of characters will
+// result in a total score of 1.
+//
+// The best case, this character is a match, and either this is the start
+// of the string, or the previous character was also a match.
+const SCORE_CONTINUE_MATCH = 1,
+  // A new match at the start of a word scores better than a new match
+  // elsewhere as it's more likely that the user will type the starts
+  // of fragments.
+  // NOTE: We score word jumps between spaces slightly higher than slashes, brackets
+  // hyphens, etc.
+  SCORE_SPACE_WORD_JUMP = 0.9,
+  SCORE_NON_SPACE_WORD_JUMP = 0.8,
+  // Any other match isn't ideal, but we include it for completeness.
+  SCORE_CHARACTER_JUMP = 0.17,
+  // If the user transposed two letters, it should be significantly penalized.
+  //
+  // i.e. "ouch" is more likely than "curtain" when "uc" is typed.
+  SCORE_TRANSPOSITION = 0.1,
+  // The goodness of a match should decay slightly with each missing
+  // character.
+  //
+  // i.e. "bad" is more likely than "bard" when "bd" is typed.
+  //
+  // This will not change the order of suggestions based on SCORE_* until
+  // 100 characters are inserted between matches.
+  PENALTY_SKIPPED = 0.999,
+  // The goodness of an exact-case match should be higher than a
+  // case-insensitive match by a small amount.
+  //
+  // i.e. "HTML" is more likely than "haml" when "HM" is typed.
+  //
+  // This will not change the order of suggestions based on SCORE_* until
+  // 1000 characters are inserted between matches.
+  PENALTY_CASE_MISMATCH = 0.9999,
+  // If the word has more characters than the user typed, it should
+  // be penalised slightly.
+  //
+  // i.e. "html" is more likely than "html5" if I type "html".
+  //
+  // However, it may well be the case that there's a sensible secondary
+  // ordering (like alphabetical) that it makes sense to rely on when
+  // there are many prefix matches, so we don't make the penalty increase
+  // with the number of tokens.
+  PENALTY_NOT_COMPLETE = 0.99
+
+const IS_GAP_REGEXP = /[\\/_+.#"@[({&]/,
+  COUNT_GAPS_REGEXP = /[\\/_+.#"@[({&]/g,
+  IS_SPACE_REGEXP = /[\s-]/,
+  COUNT_SPACE_REGEXP = /[\s-]/g
+
+function commandScoreInner(
+  string: string,
+  abbreviation: string,
+  lowerString: string,
+  lowerAbbreviation: string,
+  stringIndex: number,
+  abbreviationIndex: number,
+  memoizedResults: Map<string, number>,
+): number {
+  if (abbreviationIndex === abbreviation.length) {
+    if (stringIndex === string.length) {
+      return SCORE_CONTINUE_MATCH
+    }
+    return PENALTY_NOT_COMPLETE
+  }
+
+  const memoizeKey = `${stringIndex},${abbreviationIndex}`
+  const cached = memoizedResults.get(memoizeKey)
+  if (cached !== undefined) return cached
+
+  const abbreviationChar = lowerAbbreviation.charAt(abbreviationIndex)
+  let index = lowerString.indexOf(abbreviationChar, stringIndex)
+  let highScore = 0
+
+  while (index >= 0) {
+    let score = commandScoreInner(
+      string,
+      abbreviation,
+      lowerString,
+      lowerAbbreviation,
+      index + 1,
+      abbreviationIndex + 1,
+      memoizedResults,
+    )
+    if (score > highScore) {
+      if (index === stringIndex) {
+        score *= SCORE_CONTINUE_MATCH
+      } else if (IS_GAP_REGEXP.test(string.charAt(index - 1))) {
+        score *= SCORE_NON_SPACE_WORD_JUMP
+        const wordBreaks = string.slice(stringIndex, index - 1).match(COUNT_GAPS_REGEXP)
+        if (wordBreaks && stringIndex > 0) {
+          score *= Math.pow(PENALTY_SKIPPED, wordBreaks.length)
+        }
+      } else if (IS_SPACE_REGEXP.test(string.charAt(index - 1))) {
+        score *= SCORE_SPACE_WORD_JUMP
+        const spaceBreaks = string.slice(stringIndex, index - 1).match(COUNT_SPACE_REGEXP)
+        if (spaceBreaks && stringIndex > 0) {
+          score *= Math.pow(PENALTY_SKIPPED, spaceBreaks.length)
+        }
+      } else {
+        score *= SCORE_CHARACTER_JUMP
+        if (stringIndex > 0) {
+          score *= Math.pow(PENALTY_SKIPPED, index - stringIndex)
+        }
+      }
+
+      if (string.charAt(index) !== abbreviation.charAt(abbreviationIndex)) {
+        score *= PENALTY_CASE_MISMATCH
+      }
+    }
+
+    if (
+      (score < SCORE_TRANSPOSITION &&
+        lowerString.charAt(index - 1) === lowerAbbreviation.charAt(abbreviationIndex + 1)) ||
+      (lowerAbbreviation.charAt(abbreviationIndex + 1) ===
+        lowerAbbreviation.charAt(abbreviationIndex) && // allow duplicate letters. Ref #7428
+        lowerString.charAt(index - 1) !== lowerAbbreviation.charAt(abbreviationIndex))
+    ) {
+      const transposedScore = commandScoreInner(
+        string,
+        abbreviation,
+        lowerString,
+        lowerAbbreviation,
+        index + 1,
+        abbreviationIndex + 2,
+        memoizedResults,
+      )
+
+      if (transposedScore * SCORE_TRANSPOSITION > score) {
+        score = transposedScore * SCORE_TRANSPOSITION
+      }
+    }
+
+    if (score > highScore) {
+      highScore = score
+    }
+
+    index = lowerString.indexOf(abbreviationChar, index + 1)
+  }
+
+  memoizedResults.set(memoizeKey, highScore)
+  return highScore
+}
+
+function formatInput(string: string) {
+  // convert all valid space characters to space so they match each other
+  return string.toLowerCase().replace(COUNT_SPACE_REGEXP, ' ')
+}
+
+export function commandScore(
+  string: string,
+  abbreviation: string,
+  aliases: ReadonlyArray<string> = [],
+): number {
+  /* NOTE:
+   * in the original, we used to do the lower-casing on each recursive call, but this meant that toLowerCase()
+   * was the dominating cost in the algorithm, passing both is a little ugly, but considerably faster.
+   */
+  string = aliases && aliases.length > 0 ? `${string + ' ' + aliases.join(' ')}` : string
+  return commandScoreInner(
+    string,
+    abbreviation,
+    formatInput(string),
+    formatInput(abbreviation),
+    0,
+    0,
+    new Map(),
+  )
+}

--- a/packages/registry/registry/default/ui/command.ts
+++ b/packages/registry/registry/default/ui/command.ts
@@ -1,22 +1,21 @@
-/** ⚠ BEHAVIOR GAP vs upstream shadcn: no filtering, no arrow-key/Enter selection, no roving tabindex and no Dialog wrapper — all behavior is consumer-owned. Consider `combobox` for a searchable dropdown with real behavior.
- *  The styled surface matches, but this behavior is absent — do not use
- *  where that behavior is required.
- */
-import type { Html, HtmlBuilder } from 'foldkit/html'
+import { Effect, Option, Schema as S } from 'effect'
+import * as RuntimeCommand from 'foldkit/command'
+import * as Mount from 'foldkit/mount'
+import * as Dom from 'foldkit/dom'
+import * as Update from 'foldkit/update'
+import { defineMessageUnion } from 'foldkit/message'
+import { defineView } from 'foldkit/submodel'
+import * as Dialog from './dialog'
+import { commandScore } from './command-score'
+
+import type { Attribute, Html, HtmlBuilder, KeyboardModifiers } from 'foldkit/html'
 
 import { cn } from '@/lib/utils'
 import { icon } from '@/lib/icons'
-import { Search } from 'lucide'
+import { Check, Search } from 'lucide'
 import { inputGroup, inputGroupAddon, inputGroupInput } from './input-group'
 
 type Child = Html | string
-
-// foldcn gaps vs upstream: no cmdk behavior layer (filtering, arrow-key
-// selection and Enter-to-select are consumer-owned) and no Dialog wrapper
-// (CommandDialog missing export is OK — document gap); the [cmdk-*] descendant
-// selectors in the group token are inert here — use Command.group for heading
-// styles. Input wrapper now uses cn-command-input-wrapper/group tokens per
-// upstream; item/group/separator are bare cn-* tokens (layout in style-nova.css).
 
 export const commandClass = 'cn-command flex size-full flex-col overflow-hidden'
 
@@ -29,7 +28,7 @@ export const commandEmptyClass = 'cn-command-empty'
 
 export const commandGroupClass = 'cn-command-group'
 
-export const commandGroupHeadingClass = 'cn-command-group'
+export const commandGroupHeadingClass = ''
 
 export const commandItemClass =
   'cn-command-item group/command-item data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0'
@@ -40,6 +39,8 @@ export const commandShortcutClass = 'cn-command-shortcut'
 
 export type CommandInputConfig<M> = Readonly<{
   id?: string
+  ariaLabel?: string
+  attributes?: ReadonlyArray<Attribute<M>>
   value?: string
   onInput?: (value: string) => M
   placeholder?: string
@@ -67,13 +68,17 @@ const commandInput = <M>(config: CommandInputConfig<M>, h: HtmlBuilder<M>): Html
           inputGroupInput(
             {
               id: config.id ?? 'command-input',
-              ariaLabel: 'Search commands',
+              ariaLabel: config.ariaLabel ?? 'Search commands',
               onInput: config.onInput,
               value: config.value,
               isDisabled: config.isDisabled,
               placeholder: config.placeholder,
               className: cn(commandInputClass, config.className),
-              attributes: [h.DataAttribute('slot', 'command-input')],
+              attributes: [
+                h.DataAttribute('slot', 'command-input'),
+                h.Attribute('cmdk-input', ''),
+                ...(config.attributes ?? []),
+              ],
             },
             h,
           ),
@@ -87,14 +92,21 @@ const commandList = <M>(
   config: StyleConfig,
   children: ReadonlyArray<Child>,
   h: HtmlBuilder<M>,
-): Html => h.div([h.Class(cn(commandListClass)), h.DataAttribute('slot', 'command-list')], children)
+): Html =>
+  h.div(
+    [h.Class(cn(commandListClass, config.className)), h.DataAttribute('slot', 'command-list')],
+    children,
+  )
 
 const commandEmpty = <M>(
   config: StyleConfig,
   children: ReadonlyArray<Child>,
   h: HtmlBuilder<M>,
 ): Html =>
-  h.div([h.Class(cn(commandEmptyClass)), h.DataAttribute('slot', 'command-empty')], children)
+  h.div(
+    [h.Class(cn(commandEmptyClass, config.className)), h.DataAttribute('slot', 'command-empty')],
+    children,
+  )
 
 const commandGroup = <M>(
   config: StyleConfig,
@@ -102,12 +114,24 @@ const commandGroup = <M>(
   h: HtmlBuilder<M>,
 ): Html =>
   h.div(
-    [h.Class(cn(commandGroupClass)), h.DataAttribute('slot', 'command-group'), h.Role('group')],
+    [
+      h.Class(cn(commandGroupClass, config.className)),
+      h.DataAttribute('slot', 'command-group'),
+      h.Role('group'),
+    ],
     children,
   )
 
+export type CommandItemConfig<M> = StyleConfig &
+  Readonly<{
+    isSelected?: boolean
+    isDisabled?: boolean
+    isChecked?: boolean
+    attributes?: ReadonlyArray<Attribute<M>>
+  }>
+
 const commandItem = <M>(
-  config: StyleConfig & Readonly<{ isSelected?: boolean; isDisabled?: boolean }>,
+  config: CommandItemConfig<M>,
   children: ReadonlyArray<Child>,
   h: HtmlBuilder<M>,
 ): Html =>
@@ -115,9 +139,14 @@ const commandItem = <M>(
     [
       h.Class(cn(commandItemClass, config.className)),
       h.DataAttribute('slot', 'command-item'),
-      h.Role('menuitem'),
+      h.Attribute('cmdk-item', ''),
+      h.Role('option'),
+      h.AriaSelected(config.isSelected === true),
+      h.AriaDisabled(config.isDisabled === true),
       ...(config.isSelected === true ? [h.DataAttribute('selected', 'true')] : []),
       ...(config.isDisabled === true ? [h.DataAttribute('disabled', 'true')] : []),
+      ...(config.isChecked === true ? [h.DataAttribute('checked', 'true')] : []),
+      ...(config.attributes ?? []),
     ],
     children,
   )
@@ -155,3 +184,521 @@ export const Command = Object.assign(commandContainer, {
   separator: commandSeparator,
   shortcut: commandShortcut,
 })
+
+/** Command owns query and active value; applications own items and actions. */
+export const Model = S.Struct({ id: S.String, search: S.String, value: S.Option(S.String) })
+export type Model = typeof Model.Type
+export const Message = defineMessageUnion({
+  ChangedSearch: { search: S.String },
+  Activated: { value: S.String, scroll: S.Boolean },
+  Selected: { value: S.String },
+  CompletedScroll: {},
+  Mounted: {},
+  IgnoredKey: {},
+})
+export type Message = typeof Message.Type
+export const OutMessage = defineMessageUnion({
+  Selected: { value: S.String },
+  SearchChanged: { search: S.String },
+  ValueChanged: { value: S.String },
+})
+export type OutMessage = typeof OutMessage.Type
+export type InitConfig = Readonly<{ id: string; search?: string; value?: string }>
+export const init = ({ id, search = '', value }: InitConfig): Model => ({
+  id,
+  search,
+  value: Option.fromNullishOr(value),
+})
+
+export const inputId = (id: string): string => `${id}-input`
+const itemId = (id: string, value: string): string => `${id}-item-${encodeURIComponent(value)}`
+
+export const ScrollActive = RuntimeCommand.define('ScrollCommandActive', {
+  args: { id: S.String, value: S.String },
+  messages: [Message.CompletedScroll],
+  execute: ({ id, value }) =>
+    Dom.scrollIntoViewAfterPaint(`[id="${itemId(id, value).replaceAll('"', '\\"')}"]`, {
+      block: 'nearest',
+    }).pipe(Effect.ignore, Effect.as(Message.CompletedScroll())),
+})
+
+export const update = (
+  model: Model,
+  message: Message,
+): Update.ReturnWithOutMessage<Model, Message, OutMessage> => {
+  switch (message._tag) {
+    case 'ChangedSearch':
+      return {
+        model: { ...model, search: message.search, value: Option.none() },
+        outMessage: OutMessage.SearchChanged({ search: message.search }),
+      }
+    case 'Activated':
+      return {
+        model: { ...model, value: Option.some(message.value) },
+        commands: message.scroll ? [ScrollActive({ id: model.id, value: message.value })] : [],
+        outMessage: OutMessage.ValueChanged({ value: message.value }),
+      }
+    case 'Selected':
+      return { model, outMessage: OutMessage.Selected({ value: message.value }) }
+    case 'CompletedScroll':
+    case 'Mounted':
+    case 'IgnoredKey':
+      return { model }
+  }
+}
+
+export type Item = Readonly<{
+  /** Unique, stable action identifier. */
+  value: string
+  /** Defaults to value. The default filter searches this label and keywords. */
+  label?: string
+  keywords?: ReadonlyArray<string>
+  group?: string
+  isDisabled?: boolean
+  isChecked?: boolean
+  forceMount?: boolean
+  content?: Html
+  shortcut?: string
+}>
+export type Group = Readonly<{ value: string; heading: string; forceMount?: boolean }>
+export type Filter = (value: string, search: string, keywords: ReadonlyArray<string>) => number
+export type ViewInputs = Readonly<{
+  items: ReadonlyArray<Item>
+  groups?: ReadonlyArray<Group>
+  label?: string
+  placeholder?: string
+  emptyText?: string
+  loop?: boolean
+  vimBindings?: boolean
+  disablePointerSelection?: boolean
+  shouldFilter?: boolean
+  filter?: Filter
+  loading?: boolean
+  loadingText?: string
+  className?: string
+}>
+
+/** Ranked, grouped results in the same order that view and navigation use. */
+export const getResults = (search: string, config: ViewInputs): ReadonlyArray<Item> => {
+  const query = search.trim()
+  const shouldRank = config.shouldFilter !== false && query.length > 0
+  const filter = config.filter ?? commandScore
+  const ranked = config.items
+    .map((item) => ({
+      item,
+      score: shouldRank
+        ? filter(
+            (item.label ?? item.value).trim(),
+            query,
+            (item.keywords ?? []).map((word) => word.trim()),
+          )
+        : 1,
+    }))
+    .filter(
+      ({ item, score }) =>
+        score > 0 ||
+        item.forceMount ||
+        config.groups?.some((group) => group.value === item.group && group.forceMount),
+    )
+  if (shouldRank) ranked.sort((a, b) => b.score - a.score)
+  // Keep each group contiguous. The highest-ranked member places its group.
+  const sections = new Map<string | undefined, Array<Item>>()
+  for (const { item } of ranked) {
+    const section = sections.get(item.group)
+    if (section) section.push(item)
+    else sections.set(item.group, [item])
+  }
+  return [...sections.values()].flat()
+}
+
+export const activeItem = (model: Model, items: ReadonlyArray<Item>): Item | undefined =>
+  items.find((item) => !item.isDisabled && Option.contains(model.value, item.value)) ??
+  items.find((item) => !item.isDisabled)
+
+/** Pure navigation shared with tests. Meta jumps to an edge; Alt jumps groups. */
+export const navigate = (
+  items: ReadonlyArray<Item>,
+  value: string | undefined,
+  direction: 1 | -1,
+  loop = false,
+  byGroup = false,
+): Item | undefined => {
+  const enabled = items.filter((item) => !item.isDisabled)
+  if (enabled.length === 0) return undefined
+  const index = enabled.findIndex((item) => item.value === value)
+  const current = enabled[index]
+  if (byGroup && current) {
+    for (let next = index + direction; next >= 0 && next < enabled.length; next += direction) {
+      const item = enabled[next]
+      if (item && item.group !== current.group) return item
+    }
+  }
+  const next = index + direction
+  return enabled[
+    loop
+      ? (next + enabled.length) % enabled.length
+      : Math.max(0, Math.min(next, enabled.length - 1))
+  ]
+}
+
+// Foldkit's key helper does not expose isComposing. Guard IME events at the
+// DOM boundary before the helper sees them. Prevent mouse focus from leaving
+// the search input, and expose cmdk's measured list height for animation.
+export const CommandDom = Mount.define('MountCommandDom', {
+  messages: [Message.Mounted],
+  execute: ({ element }) =>
+    Effect.gen(function* () {
+      yield* Effect.acquireRelease(
+        Effect.sync(() => {
+          const keydown = (event: Event) => {
+            if (event instanceof KeyboardEvent && (event.isComposing || event.keyCode === 229))
+              event.stopImmediatePropagation()
+          }
+          const pointerdown = (event: Event) => {
+            if (
+              event instanceof MouseEvent &&
+              event.target instanceof Element &&
+              event.target.closest('[cmdk-item]')
+            )
+              event.preventDefault()
+          }
+          element.addEventListener('keydown', keydown, true)
+          element.addEventListener('mousedown', pointerdown)
+          const list = element.querySelector<HTMLElement>('[cmdk-list]')
+          const sizer = element.querySelector<HTMLElement>('[cmdk-list-sizer]')
+          const observer = new ResizeObserver(() => {
+            if (list && sizer)
+              list.style.setProperty('--cmdk-list-height', `${sizer.offsetHeight}px`)
+          })
+          if (sizer) observer.observe(sizer)
+          return () => {
+            element.removeEventListener('keydown', keydown, true)
+            element.removeEventListener('mousedown', pointerdown)
+            observer.disconnect()
+          }
+        }),
+        (cleanup) => Effect.sync(cleanup),
+      )
+      return Message.Mounted()
+    }),
+})
+
+export const view = defineView<Model, Message, ViewInputs>((model, config, h) => {
+  const items = getResults(model.search, config)
+  const active = activeItem(model, items)
+  const enabled = items.filter((item) => !item.isDisabled)
+  const activate = (item: Item | undefined) =>
+    Option.some(
+      item ? Message.Activated({ value: item.value, scroll: true }) : Message.IgnoredKey(),
+    )
+  const keydown = (key: string, modifiers: KeyboardModifiers): Option.Option<Message> => {
+    if (key === 'Enter')
+      return Option.some(active ? Message.Selected({ value: active.value }) : Message.IgnoredKey())
+    if (key === 'Home') return activate(enabled[0])
+    if (key === 'End') return activate(enabled.at(-1))
+    const down =
+      key === 'ArrowDown' ||
+      (config.vimBindings !== false && modifiers.ctrlKey && (key === 'n' || key === 'j'))
+    const up =
+      key === 'ArrowUp' ||
+      (config.vimBindings !== false && modifiers.ctrlKey && (key === 'p' || key === 'k'))
+    if (!down && !up) return Option.none()
+    if (modifiers.metaKey) return activate(down ? enabled.at(-1) : enabled[0])
+    return activate(navigate(items, active?.value, down ? 1 : -1, config.loop, modifiers.altKey))
+  }
+  const renderItem = (item: Item): Html =>
+    Command.item(
+      {
+        isSelected: active?.value === item.value,
+        isDisabled: item.isDisabled,
+        isChecked: item.isChecked,
+        attributes: [
+          h.Id(itemId(model.id, item.value)),
+          h.Tabindex(-1),
+          h.DataAttribute('value', item.value),
+          ...(!item.isDisabled ? [h.OnClick(Message.Selected({ value: item.value }))] : []),
+          ...(!item.isDisabled && !config.disablePointerSelection
+            ? [
+                h.OnPointerMove((_x, _y, pointerType) =>
+                  pointerType === 'touch' || active?.value === item.value
+                    ? Option.none()
+                    : Option.some(Message.Activated({ value: item.value, scroll: false })),
+                ),
+              ]
+            : []),
+        ],
+      },
+      [
+        item.content ?? item.label ?? item.value,
+        ...(item.shortcut
+          ? [Command.shortcut({}, [item.shortcut], h)]
+          : [icon(h, Check, 'cn-command-item-indicator')]),
+      ],
+      h,
+    )
+  const sections = new Map<string | undefined, Array<Item>>()
+  for (const item of items) {
+    const section = sections.get(item.group)
+    if (section) section.push(item)
+    else sections.set(item.group, [item])
+  }
+  // Keep empty groups mounted and hidden, matching cmdk's styling contract.
+  for (const group of config.groups ?? [])
+    if (!sections.has(group.value)) sections.set(group.value, [])
+  const children: Array<Html> = []
+  for (const [group, entries] of sections) {
+    if (group === undefined) {
+      children.push(...entries.map(renderItem))
+      continue
+    }
+    const metadata = config.groups?.find((entry) => entry.value === group)
+    const hidden = entries.length === 0 && !metadata?.forceMount
+    const headingId = `${model.id}-heading-${encodeURIComponent(group)}`
+    if (children.length > 0 && !model.search.trim() && !hidden)
+      children.push(
+        h.div([
+          h.Attribute('cmdk-separator', ''),
+          h.DataAttribute('slot', 'command-separator'),
+          h.Role('separator'),
+          h.Class(commandSeparatorClass),
+        ]),
+      )
+    children.push(
+      h.div(
+        [
+          h.Attribute('cmdk-group', ''),
+          h.DataAttribute('slot', 'command-group'),
+          h.Class(commandGroupClass),
+          ...(hidden ? [h.Hidden(true)] : []),
+        ],
+        [
+          h.div(
+            [
+              h.Id(headingId),
+              h.Attribute('cmdk-group-heading', ''),
+              h.DataAttribute('slot', 'command-group-heading'),
+              h.Class(commandGroupHeadingClass),
+            ],
+            [metadata?.heading ?? group],
+          ),
+          h.div(
+            [h.Role('group'), h.AriaLabelledBy(headingId), h.Attribute('cmdk-group-items', '')],
+            entries.map(renderItem),
+          ),
+        ],
+      ),
+    )
+  }
+  return h.div(
+    [
+      h.Attribute('cmdk-root', ''),
+      h.DataAttribute('slot', 'command'),
+      h.Class(cn(commandClass, config.className)),
+      h.OnMount(CommandDom()),
+    ],
+    [
+      Command.input(
+        {
+          id: inputId(model.id),
+          ariaLabel: config.label ?? 'Command menu',
+          value: model.search,
+          onInput: (search) => Message.ChangedSearch({ search }),
+          placeholder: config.placeholder ?? 'Type a command or search...',
+          attributes: [
+            h.Role('combobox'),
+            h.AriaExpanded(true),
+            h.AriaControls(`${model.id}-list`),
+            h.Attribute('aria-autocomplete', 'list'),
+            h.Autocomplete('off'),
+            h.OnKeyDownPreventDefault(keydown),
+            ...(active ? [h.AriaActiveDescendant(itemId(model.id, active.value))] : []),
+          ],
+        },
+        h,
+      ),
+      h.div(
+        [
+          h.Id(`${model.id}-list`),
+          h.Role('listbox'),
+          h.AriaLabel(config.label ?? 'Commands'),
+          h.Attribute('cmdk-list', ''),
+          h.DataAttribute('slot', 'command-list'),
+          h.Class(commandListClass),
+        ],
+        [
+          h.div(
+            [h.Attribute('cmdk-list-sizer', '')],
+            [
+              ...(config.loading
+                ? [
+                    h.div(
+                      [
+                        h.Attribute('cmdk-loading', ''),
+                        h.Role('progressbar'),
+                        h.AriaLabel(config.loadingText ?? 'Loading commands'),
+                      ],
+                      [config.loadingText ?? 'Loading commands...'],
+                    ),
+                  ]
+                : []),
+              ...(items.length === 0
+                ? [
+                    h.div(
+                      [
+                        h.Attribute('cmdk-empty', ''),
+                        h.DataAttribute('slot', 'command-empty'),
+                        h.Role('status'),
+                        h.Class(commandEmptyClass),
+                      ],
+                      [config.emptyText ?? 'No results found.'],
+                    ),
+                  ]
+                : []),
+              ...children,
+            ],
+          ),
+        ],
+      ),
+    ],
+  )
+})
+
+export const CommandDialogModel = S.Struct({
+  command: Model,
+  dialog: Dialog.Model,
+  closeOnSelect: S.Boolean,
+  resetOnOpen: S.Boolean,
+})
+export type CommandDialogModel = typeof CommandDialogModel.Type
+export const CommandDialogMessage = defineMessageUnion({
+  GotCommandMessage: { message: Message },
+  GotDialogMessage: { message: Dialog.Message },
+})
+export type CommandDialogMessage = typeof CommandDialogMessage.Type
+export const CommandDialogOutMessage = defineMessageUnion({
+  Selected: { value: S.String },
+  SearchChanged: { search: S.String },
+  ValueChanged: { value: S.String },
+  Opened: {},
+  Closed: {},
+})
+export type CommandDialogOutMessage = typeof CommandDialogOutMessage.Type
+
+type DialogUpdate = Update.ReturnWithOutMessage<
+  CommandDialogModel,
+  CommandDialogMessage,
+  CommandDialogOutMessage
+>
+const dialogInit = (
+  config: InitConfig &
+    Readonly<{ closeOnSelect?: boolean; resetOnOpen?: boolean; isAnimated?: boolean }>,
+): CommandDialogModel => ({
+  command: init(config),
+  dialog: Dialog.init({
+    id: `${config.id}-dialog`,
+    focusSelector: `[id="${inputId(config.id)}"]`,
+    isAnimated: config.isAnimated ?? true,
+  }),
+  closeOnSelect: config.closeOnSelect ?? false,
+  resetOnOpen: config.resetOnOpen ?? false,
+})
+const foldDialogResult = (
+  model: CommandDialogModel,
+  result: ReturnType<typeof Dialog.update>,
+): DialogUpdate => {
+  const folded = {
+    model: { ...model, dialog: result.model },
+    commands: RuntimeCommand.mapMessages(result.commands ?? [], (message) =>
+      CommandDialogMessage.GotDialogMessage({ message }),
+    ),
+  }
+  return result.outMessage ? Update.withOutMessage(folded, result.outMessage) : folded
+}
+const dialogOpen = (model: CommandDialogModel): DialogUpdate =>
+  foldDialogResult(
+    {
+      ...model,
+      command:
+        model.resetOnOpen && !model.dialog.isOpen ? init({ id: model.command.id }) : model.command,
+    },
+    Dialog.open(model.dialog),
+  )
+const dialogClose = (model: CommandDialogModel): DialogUpdate =>
+  foldDialogResult(model, Dialog.close(model.dialog))
+const dialogUpdate = (model: CommandDialogModel, message: CommandDialogMessage): DialogUpdate => {
+  if (message._tag === 'GotDialogMessage')
+    return foldDialogResult(model, Dialog.update(model.dialog, message.message))
+  const result = update(model.command, message.message)
+  const next = { ...model, command: result.model }
+  const closed =
+    result.outMessage?._tag === 'Selected' && model.closeOnSelect
+      ? dialogClose(next)
+      : { model: next, commands: [] }
+  const folded = {
+    model: closed.model,
+    commands: [
+      ...RuntimeCommand.mapMessages(result.commands ?? [], (message) =>
+        CommandDialogMessage.GotCommandMessage({ message }),
+      ),
+      ...(closed.commands ?? []),
+    ],
+  }
+  return result.outMessage ? Update.withOutMessage(folded, result.outMessage) : folded
+}
+export type CommandDialogViewInputs = ViewInputs &
+  Readonly<{ title?: string; description?: string; showCloseButton?: boolean; panelClass?: string }>
+const dialogView = defineView<CommandDialogModel, CommandDialogMessage, CommandDialogViewInputs>(
+  (model, config, h) =>
+    h.submodel({
+      slotId: model.dialog.id,
+      model: model.dialog,
+      view: Dialog.view,
+      viewInputs: Dialog.styledViewInputs(
+        {
+          panelClass: cn('cn-command-dialog', config.panelClass),
+          content: (render, inner) => [
+            Dialog.header(
+              { className: 'cn-command-dialog-header' },
+              [
+                Dialog.title(
+                  { attributes: render.title },
+                  [config.title ?? 'Command Palette'],
+                  inner,
+                ),
+                Dialog.description(
+                  { attributes: render.description },
+                  [config.description ?? 'Search for a command to run...'],
+                  inner,
+                ),
+              ],
+              inner,
+            ),
+            inner.submodel({
+              slotId: model.command.id,
+              model: model.command,
+              view,
+              viewInputs: config,
+              toParentMessage: (message) => CommandDialogMessage.GotCommandMessage({ message }),
+            }),
+            ...(config.showCloseButton
+              ? [Dialog.closeButton({ attributes: render.closeButton }, ['Close'], inner)]
+              : []),
+          ],
+        },
+        h,
+      ),
+      toParentMessage: (message) => CommandDialogMessage.GotDialogMessage({ message }),
+    }),
+)
+
+/** One child owns both command interaction and the modal lifecycle. */
+export const CommandDialog = {
+  Model: CommandDialogModel,
+  Message: CommandDialogMessage,
+  OutMessage: CommandDialogOutMessage,
+  init: dialogInit,
+  open: dialogOpen,
+  close: dialogClose,
+  update: dialogUpdate,
+  view: dialogView,
+}

--- a/packages/registry/registry/default/ui/registry.json
+++ b/packages/registry/registry/default/ui/registry.json
@@ -776,11 +776,20 @@
       "name": "command",
       "type": "registry:ui",
       "title": "Command",
-      "description": "Presentational command-palette surface with input, list, group and item builders. \u26a0 No cmdk behavior: filtering and arrow-key/Enter selection are consumer-owned \u2014 consider combobox instead.",
-      "registryDependencies": ["@foldcn/utils", "@foldcn/icons"],
+      "description": "Command palette with fuzzy search, ranked groups, keyboard and pointer selection, and a composed CommandDialog.",
+      "registryDependencies": [
+        "@foldcn/utils",
+        "@foldcn/icons",
+        "@foldcn/input-group",
+        "@foldcn/dialog"
+      ],
       "files": [
         {
           "path": "command.ts",
+          "type": "registry:ui"
+        },
+        {
+          "path": "command-score.ts",
           "type": "registry:ui"
         }
       ]

--- a/packages/registry/scripts/resolve-styles.mjs
+++ b/packages/registry/scripts/resolve-styles.mjs
@@ -291,7 +291,7 @@ function transformSourceFile(sourceFile, styleMap, unmappedTokens) {
     // Inert-selector cleanup runs on EVERY literal — resolved tokens and
     // hand-written tails alike — so upstream-copied selectors that can never
     // match foldkit's emitted attributes don't ship to users:
-    //   - `[cmdk-*]` descendant selectors (no cmdk behavior layer)
+    // Command now emits cmdk-* attributes; preserve those selectors.
     //   - `data-[selected=true]:…` (foldkit emits data-selected as EMPTY attr)
     //   - `data-[disabled=true]` → `data-[disabled]` (same empty-attr rule as
     //     the style-map foldkitCompat pass above)
@@ -303,10 +303,7 @@ function transformSourceFile(sourceFile, styleMap, unmappedTokens) {
 const stripInertUtilities = (classes) =>
   classes
     .split(/\s+/)
-    .filter(
-      (utility) =>
-        utility !== '' && !utility.includes('[cmdk-') && !/^data-\[selected=true\]:/.test(utility),
-    )
+    .filter((utility) => utility !== '' && !/^data-\[selected=true\]:/.test(utility))
     .map((utility) => utility.replace(/data-\[disabled=true\]/g, 'data-[disabled]'))
     .join(' ')
 

--- a/packages/web/scripts/verify-command-composition.mjs
+++ b/packages/web/scripts/verify-command-composition.mjs
@@ -1,0 +1,182 @@
+// Run on /docs/command in the dev server; see docs/command-composition.md.
+export const verifyCommandComposition = async () => {
+  // Wait for the runtime's mount hook, rather than interacting with SSR markup.
+  for (let attempt = 0; attempt < 200; attempt++) {
+    if (document.querySelector('[cmdk-list]')?.style.getPropertyValue('--cmdk-list-height')) break
+    if (attempt === 199) throw new Error('Command runtime did not mount within 10 seconds.')
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  const trigger = document.getElementById('command-dialog-trigger')
+  const inline = document.getElementById('command-inline-input')
+  if (!(trigger instanceof HTMLButtonElement) || !(inline instanceof HTMLInputElement))
+    throw new Error('Open /docs/command first.')
+  const pause = () => new Promise((resolve) => setTimeout(resolve, 160))
+  const waitFor = async (test, label) => {
+    for (let attempt = 0; attempt < 100; attempt++) {
+      if (test()) return
+      await new Promise((resolve) => setTimeout(resolve, 20))
+    }
+    throw new Error(label)
+  }
+  const assert = (condition, message) => {
+    if (!condition) throw new Error(message)
+  }
+  const status = () => document.querySelector('[data-command-result]')?.textContent ?? ''
+  const count = () => Number(status().match(/Commands run: (\d+)/)?.[1] ?? 0)
+  const initialCount = count()
+  const options = (input) => [...input.closest('[cmdk-root]').querySelectorAll('[cmdk-item]')]
+  const active = (input) =>
+    document.getElementById(input.getAttribute('aria-activedescendant'))?.getAttribute('data-value')
+  const key = async (input, value, modifiers = {}) => {
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', { key: value, bubbles: true, cancelable: true, ...modifiers }),
+    )
+    await pause()
+  }
+  const type = async (input, query) => {
+    input.focus()
+    input.value = query
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    await pause()
+  }
+  const open = async () => {
+    trigger.scrollIntoView({ block: 'center' })
+    trigger.focus()
+    trigger.click()
+    await waitFor(
+      () => document.getElementById('command-demo-dialog')?.open,
+      'Dialog failed to open',
+    )
+    const input = document.getElementById('command-demo-input')
+    assert(input instanceof HTMLInputElement, 'Dialog input missing')
+    await waitFor(() => document.activeElement === input, 'Dialog did not focus search')
+    return input
+  }
+  const closed = async () => {
+    await waitFor(
+      () => !document.getElementById('command-demo-dialog')?.open,
+      'Dialog failed to close',
+    )
+    await waitFor(() => document.activeElement === trigger, 'Dialog did not restore trigger focus')
+  }
+  assert(
+    !document.getElementById('command-demo-dialog')?.open,
+    'Close the dialog before running this check',
+  )
+
+  await type(inline, 'clndr')
+  assert(
+    options(inline).length === 1 && active(inline) === 'calendar',
+    'Inline fuzzy filtering failed',
+  )
+  await key(inline, 'Enter')
+  assert(
+    count() === initialCount + 1 && status().includes('Ran calendar.'),
+    'Inline selection failed',
+  )
+  assert(
+    inline.value === 'clndr' && options(inline).length === 1,
+    'Inline selection must preserve search and list',
+  )
+  await type(inline, '')
+  await key(inline, 'End')
+  assert(active(inline) === 'settings', 'End failed')
+  await key(inline, 'ArrowDown')
+  assert(active(inline) === 'calendar', 'Loop failed')
+  await key(inline, 'ArrowDown', { altKey: true })
+  assert(active(inline) === 'profile', 'Group navigation failed')
+  await key(inline, 'Home')
+  await key(inline, 'j', { ctrlKey: true })
+  assert(active(inline) === 'emoji', 'Vim navigation failed')
+  await key(inline, 'ArrowDown')
+  assert(active(inline) === 'profile', 'Navigation did not skip disabled item')
+  await key(inline, 'ArrowUp')
+  assert(active(inline) === 'emoji', 'Reverse navigation did not skip disabled item')
+
+  let input = await open()
+  assert(options(input).length === 6, 'Dialog results must be visible without typing')
+  assert(active(input) === 'calendar', 'First enabled item must be active')
+  assert(
+    input.closest('dialog').getAttribute('aria-labelledby'),
+    'Dialog title association missing',
+  )
+  await type(input, 'payment')
+  assert(
+    active(input) === 'billing' && options(input).length === 1,
+    'Keyword alias filtering failed',
+  )
+  await key(input, 'Enter', { isComposing: true })
+  assert(
+    count() === initialCount + 1 && input.closest('dialog').open,
+    'IME Enter executed a command',
+  )
+  await key(input, 'Enter')
+  await closed()
+  assert(
+    count() === initialCount + 2 && status().includes('Ran billing.'),
+    'Dialog Enter selection failed',
+  )
+
+  input = await open()
+  assert(input.value === '', 'Configured resetOnOpen failed')
+  const billing = options(input).find((item) => item.getAttribute('data-value') === 'billing')
+  assert(billing, 'Billing result missing')
+  billing.dispatchEvent(
+    new PointerEvent('pointermove', {
+      bubbles: true,
+      pointerType: 'mouse',
+      screenX: 30,
+      screenY: 40,
+    }),
+  )
+  await pause()
+  assert(active(input) === 'billing', 'Pointer hover did not activate item')
+  const bounds = billing.getBoundingClientRect()
+  assert(
+    billing.contains(
+      document.elementFromPoint(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2),
+    ),
+    'Dialog option is covered',
+  )
+  billing.click()
+  await closed()
+  assert(count() === initialCount + 3, 'Repeated pointer selection failed')
+
+  input = await open()
+  await type(input, 'calculator')
+  assert(
+    options(input).length === 1 && options(input)[0].getAttribute('aria-disabled') === 'true',
+    'Disabled results missing',
+  )
+  assert(!input.hasAttribute('aria-activedescendant'), 'Disabled item became active')
+  options(input)[0].click()
+  await key(input, 'Enter')
+  assert(count() === initialCount + 3, 'Disabled result executed')
+  await type(input, 'zzzz')
+  assert(
+    options(input).length === 0 &&
+      input.closest('[cmdk-root]').querySelector('[cmdk-empty]')?.textContent ===
+        'No results found.',
+    'Empty state missing',
+  )
+  await key(input, 'Enter')
+  assert(count() === initialCount + 3, 'Empty list executed a command')
+  await type(input, 'CAL')
+  assert(
+    !input.closest('[cmdk-root]').querySelector('[cmdk-empty]'),
+    'Empty state persisted after results returned',
+  )
+  assert(options(input).length === 2, 'Case-insensitive filtering failed')
+  await key(input, 'Escape')
+  await closed()
+  assert(count() === initialCount + 3, 'Escape executed an action')
+
+  // Verify the demo-owned shortcut opens and closes from outside the palette.
+  await key(trigger, 'k', { metaKey: true })
+  await waitFor(() => document.getElementById('command-demo-dialog')?.open, 'Cmd+K did not open')
+  input = document.getElementById('command-demo-input')
+  await key(input, 'k', { ctrlKey: true })
+  await closed()
+  await type(inline, '')
+  return 'Passed: inline and dialog search, aliases, fuzzy ranking, keys, groups, disabled and empty results, pointer selection, IME, repeat actions, shortcuts, and focus restoration.'
+}

--- a/packages/web/src/catalog/gaps.ts
+++ b/packages/web/src/catalog/gaps.ts
@@ -11,7 +11,7 @@
 
 export const gapsByItem = {
   command: [
-    'Presentational surface only — no filtering, arrow-key navigation, or selection. Compose with listbox or wire your own behavior.',
+    'Data-driven Foldkit API: provide stable item values and content instead of cmdk React children. CommandDialog uses Foldkit Dialog; nested pages and async fetching remain application-owned.',
   ],
   menubar: [
     'Renders independent menus in a bar — no cross-menu keyboard traversal or open-on-hover of the next trigger.',

--- a/packages/web/src/command-behavior.test.ts
+++ b/packages/web/src/command-behavior.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest'
+import { Option } from 'effect'
+import { Scene } from 'foldkit/test'
+import * as Command from '../../registry/registry/default/ui/command'
+import { commandScore } from '../../registry/registry/default/ui/command-score'
+
+const items: ReadonlyArray<Command.Item> = [
+  { value: 'calendar', label: 'Calendar', keywords: ['schedule'], group: 'tools' },
+  { value: 'calculator', label: 'Calculator', group: 'tools', isDisabled: true },
+  { value: 'profile', label: 'Profile', group: 'account' },
+  { value: 'billing', label: 'Billing', keywords: ['payment'], group: 'account' },
+]
+const config: Command.ViewInputs = {
+  items,
+  groups: [
+    { value: 'tools', heading: 'Tools' },
+    { value: 'account', heading: 'Account' },
+  ],
+}
+const values = (result: ReadonlyArray<Command.Item>) => result.map((item) => item.value)
+
+describe('cmdk scoring and filtering', () => {
+  it('prefers exact and word-boundary matches over loose character matches', () => {
+    expect(commandScore('Calendar', 'Calendar')).toBe(1)
+    expect(commandScore('Calendar', 'cal')).toBeGreaterThan(commandScore('Calculator', 'clr'))
+    expect(commandScore('Search Emoji', 'se')).toBeGreaterThan(commandScore('Somewhere', 'se'))
+    expect(commandScore('Calendar', 'clndr')).toBeGreaterThan(0)
+    expect(commandScore('Calendar', 'zzzz')).toBe(0)
+    expect(commandScore('Calendar', 'calnedar')).toBeGreaterThan(0)
+  })
+  it('filters labels and aliases, trims queries, and retains disabled matches', () => {
+    expect(values(Command.getResults(' CAL ', config))).toEqual(['calendar', 'calculator'])
+    expect(values(Command.getResults('payment', config))).toEqual(['billing'])
+    expect(values(Command.getResults('clndr', config))).toEqual(['calendar'])
+    expect(Command.getResults('zzzz', config)).toEqual([])
+  })
+  it('ranks groups by their best member and preserves declaration order for ties', () => {
+    const result = Command.getResults('x', {
+      ...config,
+      filter: (label) => (label === 'Billing' ? 1 : 0.5),
+    })
+    expect(values(result)).toEqual(['billing', 'profile', 'calendar', 'calculator'])
+    expect(values(Command.getResults('', config))).toEqual(items.map((item) => item.value))
+  })
+  it('supports custom ranking, external filtering, and forced items/groups', () => {
+    expect(
+      values(
+        Command.getResults('x', { ...config, filter: (label) => (label === 'Profile' ? 1 : 0) }),
+      ),
+    ).toEqual(['profile'])
+    expect(values(Command.getResults('zzzz', { ...config, shouldFilter: false }))).toEqual(
+      items.map((item) => item.value),
+    )
+    expect(
+      values(
+        Command.getResults('zzzz', {
+          ...config,
+          items: [...items, { value: 'always', forceMount: true }],
+        }),
+      ),
+    ).toEqual(['always'])
+    expect(
+      values(
+        Command.getResults('zzzz', {
+          ...config,
+          groups: [{ value: 'tools', heading: 'Tools', forceMount: true }],
+        }),
+      ),
+    ).toEqual(['calendar', 'calculator'])
+  })
+})
+
+describe('command state and navigation', () => {
+  it('skips disabled items, clamps by default, and wraps only when requested', () => {
+    expect(Command.navigate(items, 'calendar', 1)?.value).toBe('profile')
+    expect(Command.navigate(items, 'profile', -1)?.value).toBe('calendar')
+    expect(Command.navigate(items, 'billing', 1)?.value).toBe('billing')
+    expect(Command.navigate(items, 'billing', 1, true)?.value).toBe('calendar')
+    expect(Command.navigate(items, 'calendar', -1, true)?.value).toBe('billing')
+    expect(Command.navigate([], undefined, 1)).toBeUndefined()
+  })
+  it('jumps groups and falls back when an async result removes the active item', () => {
+    expect(Command.navigate(items, 'calendar', 1, false, true)?.value).toBe('profile')
+    expect(Command.navigate(items, 'billing', -1, false, true)?.value).toBe('calendar')
+    const model = Command.init({ id: 'test', value: 'billing' })
+    expect(Command.activeItem(model, items.slice(0, 2))?.value).toBe('calendar')
+    expect(Command.activeItem(model, [{ value: 'no', isDisabled: true }])).toBeUndefined()
+  })
+  it('search resets the active preference; selection does not erase a controlled query', () => {
+    const result = Command.update(
+      Command.init({ id: 'test', value: 'billing' }),
+      Command.Message.ChangedSearch({ search: 'cal' }),
+    )
+    expect(Option.isNone(result.model.value)).toBe(true)
+    expect(result.outMessage).toEqual(Command.OutMessage.SearchChanged({ search: 'cal' }))
+    const selected = Command.update(result.model, Command.Message.Selected({ value: 'calendar' }))
+    expect(selected.model.search).toBe('cal')
+    expect(selected.outMessage).toEqual(Command.OutMessage.Selected({ value: 'calendar' }))
+  })
+})
+
+describe('rendered Command contract', () => {
+  it('renders an inline list, chooses the first enabled result, selects on Enter and hides empty groups', () => {
+    const input = Scene.role('combobox')
+    Scene.scene(
+      { update: Command.update, view: Scene.withViewInputs(Command.view, config)() },
+      Scene.given(Command.init({ id: 'test' })),
+      Scene.Mount.resolve(Command.CommandDom, Command.Message.Mounted()),
+      Scene.expect(input).toHaveAttr('aria-activedescendant', 'test-item-calendar'),
+      Scene.expect(Scene.role('listbox')).toExist(),
+      Scene.type(input, 'payment'),
+      Scene.expect(input).toHaveAttr('aria-activedescendant', 'test-item-billing'),
+      Scene.expect(Scene.selector('[cmdk-group][hidden]')).toExist(),
+      Scene.keydown(input, 'Enter'),
+      Scene.expectOutMessage(Command.OutMessage.Selected({ value: 'billing' })),
+      Scene.type(input, 'zzzz'),
+      Scene.expect(Scene.text('No results found.')).toExist(),
+      Scene.keydown(input, 'Enter'),
+      Scene.expectNoOutMessage(),
+    )
+  })
+  it('ignores disabled clicks and supports Home/End through the real key handler', () => {
+    Scene.scene(
+      { update: Command.update, view: Scene.withViewInputs(Command.view, config)() },
+      Scene.given(Command.init({ id: 'test' })),
+      Scene.Mount.resolve(Command.CommandDom, Command.Message.Mounted()),
+      Scene.expect(Scene.role('option', { name: 'Calculator' })).toBeDisabled(),
+      Scene.expectNoOutMessage(),
+      Scene.keydown(Scene.role('combobox'), 'End'),
+      Scene.Command.resolve(Command.ScrollActive, Command.Message.CompletedScroll()),
+      Scene.expect(Scene.role('combobox')).toHaveAttr('aria-activedescendant', 'test-item-billing'),
+      Scene.keydown(Scene.role('combobox'), 'Home'),
+      Scene.Command.resolve(Command.ScrollActive, Command.Message.CompletedScroll()),
+      Scene.expect(Scene.role('combobox')).toHaveAttr(
+        'aria-activedescendant',
+        'test-item-calendar',
+      ),
+    )
+  })
+})
+
+describe('CommandDialog ownership', () => {
+  it('keeps selection and query by default, with opt-in close and reset', () => {
+    const initial = Command.CommandDialog.init({ id: 'test', search: 'cal', isAnimated: false })
+    const open = Command.CommandDialog.open(initial)
+    const selected = Command.CommandDialog.update(
+      open.model,
+      Command.CommandDialog.Message.GotCommandMessage({
+        message: Command.Message.Selected({ value: 'calendar' }),
+      }),
+    )
+    expect(selected.model.dialog.isOpen).toBe(true)
+    expect(selected.model.command.search).toBe('cal')
+    const configured = Command.CommandDialog.open(
+      Command.CommandDialog.init({
+        id: 'other',
+        closeOnSelect: true,
+        resetOnOpen: true,
+        search: 'old',
+        isAnimated: false,
+      }),
+    )
+    expect(configured.model.command.search).toBe('')
+    const closed = Command.CommandDialog.update(
+      configured.model,
+      Command.CommandDialog.Message.GotCommandMessage({
+        message: Command.Message.Selected({ value: 'billing' }),
+      }),
+    )
+    expect(closed.model.dialog.isOpen).toBe(false)
+    expect(closed.outMessage).toEqual(
+      Command.CommandDialog.OutMessage.Selected({ value: 'billing' }),
+    )
+    expect(closed.commands?.length).toBeGreaterThan(0)
+  })
+})
+
+it('routes selection through the demo parent', async () => {
+  const Demo = await import('./demo/assemble')
+  const result = Demo.update(Demo.init().model, {
+    _tag: 'GotInlineCommandMessage',
+    message: Command.Message.Selected({ value: 'calendar' }),
+  })
+  expect(result.model.commandRunCount).toBe(1)
+  expect(result.model.lastCommand).toBe('calendar')
+})
+
+// The resolver previously stripped cmdk selectors from every string literal,
+// including DOM queries. Exercise distributed source, not only authored views.
+describe('resolved Command selectors', () => {
+  const sources = import.meta.glob('../../registry/styles/*/ui/command.ts', {
+    query: '?raw',
+    import: 'default',
+    eager: true,
+  })
+  it('preserves DOM queries and group styling in every style', () => {
+    expect(Object.keys(sources)).toHaveLength(9)
+    for (const source of Object.values(sources)) {
+      expect(source).toContain("closest('[cmdk-item]')")
+      expect(source).toContain("('[cmdk-list]')")
+      expect(source).toContain("('[cmdk-list-sizer]')")
+      expect(source).toContain('[cmdk-group-heading]')
+    }
+  })
+})

--- a/packages/web/src/demo/subscriptions.ts
+++ b/packages/web/src/demo/subscriptions.ts
@@ -1,5 +1,7 @@
 import { Subscription } from 'foldkit'
 
+import { subscriptions as commandSubscriptions } from './views/command'
+
 import type { Model, Message } from './assemble'
 import { subscriptions as dragAndDropSubscriptions } from './views/drag-and-drop'
 import { subscriptions as sidebarSubscriptions } from './views/sidebar'
@@ -7,6 +9,7 @@ import { subscriptions as sliderSubscriptions } from './views/slider'
 import { subscriptions as virtualListSubscriptions } from './views/virtual-list'
 
 export const subscriptions = Subscription.aggregate<Model, Message>()(
+  commandSubscriptions,
   dragAndDropSubscriptions,
   sidebarSubscriptions,
   sliderSubscriptions,

--- a/packages/web/src/demo/views/command.ts
+++ b/packages/web/src/demo/views/command.ts
@@ -1,9 +1,11 @@
-import { Schema as S } from 'effect'
-import { evo } from 'foldkit/struct'
+import { Subscription, Update } from 'foldkit'
+import * as RuntimeCommand from 'foldkit/command'
+import { Option, Schema as S } from 'effect'
 import { defineMessageUnion } from 'foldkit/message'
 import type { Html, HtmlBuilder } from 'foldkit/html'
 
-import { Command, commandGroupHeadingClass } from '../../generated/registry/ui/command'
+import * as Command from '../../generated/registry/ui/command'
+import { button } from '../../generated/registry/ui/button'
 import { icon } from '../../generated/registry/lib/icons'
 import { Calculator, Calendar, CreditCard, Settings, Smile, User } from 'lucide'
 
@@ -11,122 +13,227 @@ import { defineSlice, type UpdateReturn } from '../slice'
 import type { Model, Message as AppMessage } from '../assemble'
 
 const Message = defineMessageUnion({
-  UpdatedCommandSearch: { value: S.String },
+  GotInlineCommandMessage: { message: Command.Message },
+  GotCommandDialogMessage: { message: Command.CommandDialog.Message },
+  ToggledCommandDialog: {},
 })
 
-// Presentational palette mirroring apps/v4/examples/base/command-demo.tsx.
-// Filtering is parent-owned; the upstream cmdk behaviors (arrow nav, Enter
-// selection) are inert in foldcn (see registry/default/ui/command.ts).
-const GROUPS: ReadonlyArray<{
-  heading: string
-  items: ReadonlyArray<{
-    label: string
-    icon: typeof Calendar
-    disabled?: boolean
-    shortcut?: string
-  }>
-}> = [
+const fields = {
+  inlineCommand: Command.Model,
+  commandDialog: Command.CommandDialog.Model,
+  lastCommand: S.String,
+  commandRunCount: S.Number,
+}
+const stateSchema = S.Struct(fields)
+type State = typeof stateSchema.Type
+
+const commandItems = <M>(h: HtmlBuilder<M>): ReadonlyArray<Command.Item> => [
   {
-    heading: 'Suggestions',
-    items: [
-      { label: 'Calendar', icon: Calendar },
-      { label: 'Search Emoji', icon: Smile },
-      { label: 'Calculator', icon: Calculator, disabled: true },
-    ],
+    value: 'calendar',
+    label: 'Calendar',
+    keywords: ['events', 'schedule'],
+    group: 'suggestions',
+    content: iconLabel(h, Calendar, 'Calendar'),
   },
   {
-    heading: 'Settings',
-    items: [
-      { label: 'Profile', icon: User, shortcut: '⌘P' },
-      { label: 'Billing', icon: CreditCard, shortcut: '⌘B' },
-      { label: 'Settings', icon: Settings, shortcut: '⌘S' },
-    ],
+    value: 'emoji',
+    label: 'Search Emoji',
+    keywords: ['smile'],
+    group: 'suggestions',
+    content: iconLabel(h, Smile, 'Search Emoji'),
+  },
+  {
+    value: 'calculator',
+    label: 'Calculator',
+    group: 'suggestions',
+    isDisabled: true,
+    content: iconLabel(h, Calculator, 'Calculator'),
+  },
+  {
+    value: 'profile',
+    label: 'Profile',
+    keywords: ['account'],
+    group: 'settings',
+    shortcut: '⌘P',
+    content: iconLabel(h, User, 'Profile'),
+  },
+  {
+    value: 'billing',
+    label: 'Billing',
+    keywords: ['payment', 'invoice'],
+    group: 'settings',
+    shortcut: '⌘B',
+    content: iconLabel(h, CreditCard, 'Billing'),
+  },
+  {
+    value: 'settings',
+    label: 'Settings',
+    keywords: ['preferences'],
+    group: 'settings',
+    shortcut: '⌘S',
+    content: iconLabel(h, Settings, 'Settings'),
   },
 ]
+const iconLabel = <M>(h: HtmlBuilder<M>, symbol: typeof Calendar, label: string): Html =>
+  h.span([h.Class('flex items-center gap-2')], [icon(h, symbol, 'size-4'), h.span([], [label])])
+const groups: ReadonlyArray<Command.Group> = [
+  { value: 'suggestions', heading: 'Suggestions' },
+  { value: 'settings', heading: 'Settings' },
+]
+
+const recordCommand =
+  (out: Command.OutMessage | Command.CommandDialogOutMessage): Update.Step<State, unknown> =>
+  (model) => ({
+    model:
+      out._tag === 'Selected'
+        ? { ...model, lastCommand: out.value, commandRunCount: model.commandRunCount + 1 }
+        : model,
+  })
+const foldInline = Update.foldChild({
+  update: Command.update,
+  read: (model: State) => Option.some(model.inlineCommand),
+  write: (model, inlineCommand) => ({ ...model, inlineCommand }),
+  toParentMessage: (message) => Message.GotInlineCommandMessage({ message }),
+  foldOutMessage: recordCommand,
+})
+const foldDialog = Update.foldChild({
+  update: Command.CommandDialog.update,
+  read: (model: State) => Option.some(model.commandDialog),
+  write: (model, commandDialog) => ({ ...model, commandDialog }),
+  toParentMessage: (message) => Message.GotCommandDialogMessage({ message }),
+  foldOutMessage: recordCommand,
+})
 
 export const commandView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
   h.div(
-    [h.Class('flex w-full flex-col gap-8')],
+    [h.Class('flex w-full max-w-sm flex-col gap-6')],
     [
-      h.div(
-        [h.Class('flex w-full flex-col gap-2')],
+      h.h2([h.Class('text-sm font-medium')], ['Inline']),
+      h.submodel({
+        slotId: model.inlineCommand.id,
+        model: model.inlineCommand,
+        view: Command.view,
+        viewInputs: {
+          items: commandItems(h),
+          groups,
+          label: 'Inline commands',
+          loop: true,
+          className: 'rounded-lg border',
+        },
+        toParentMessage: (message) => Message.GotInlineCommandMessage({ message }),
+      }),
+      h.h2([h.Class('text-sm font-medium')], ['Dialog']),
+      button(
+        {
+          variant: 'outline',
+          onClick: Message.ToggledCommandDialog(),
+          attributes: [h.Id('command-dialog-trigger')],
+        },
+        'Open command palette',
+        h,
+      ),
+      h.p(
+        [h.Class('text-xs text-muted-foreground')],
         [
-          h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], ['Basic']),
-          (() => {
-            const query = model.commandSearch.toLowerCase()
-            const groups = GROUPS.map((group) => {
-              const items = group.items.filter((item) => item.label.toLowerCase().includes(query))
-              if (items.length === 0) return null
-              return Command.group(
-                {},
-                [
-                  h.div(
-                    [
-                      h.Class(commandGroupHeadingClass),
-                      h.DataAttribute('slot', 'command-group-heading'),
-                    ],
-                    [group.heading],
-                  ),
-                  ...items.map((item) =>
-                    Command.item(
-                      { isDisabled: item.disabled },
-                      [
-                        icon(h, item.icon, 'size-4'),
-                        h.span([], [item.label]),
-                        ...(item.shortcut ? [Command.shortcut({}, [item.shortcut], h)] : []),
-                      ],
-                      h,
-                    ),
-                  ),
-                ],
-                h,
-              )
-            }).filter((group): group is Html => group !== null)
-
-            return Command(
-              { className: 'max-w-sm rounded-lg border' },
-              [
-                Command.input(
-                  {
-                    value: model.commandSearch,
-                    onInput: (value) => Message.UpdatedCommandSearch({ value }),
-                    placeholder: 'Type a command or search...',
-                  },
-                  h,
-                ),
-                Command.list({}, [...groups, Command.empty({}, ['No results found.'], h)], h),
-              ],
-              h,
-            )
-          })(),
+          'Press ⌘K or Ctrl+K. Try “schedule”, “payment”, or “clndr”. Calculator is disabled. Shortcut hints are labels, not registered hotkeys.',
         ],
       ),
-      h.div(
-        [h.Class('flex w-full flex-col gap-2')],
+      h.submodel({
+        slotId: model.commandDialog.dialog.id,
+        model: model.commandDialog,
+        view: Command.CommandDialog.view,
+        viewInputs: {
+          items: commandItems(h),
+          groups,
+          label: 'Search commands',
+          title: 'Command Palette',
+          loop: true,
+          vimBindings: false,
+        },
+        toParentMessage: (message) => Message.GotCommandDialogMessage({ message }),
+      }),
+      h.p(
         [
-          h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], ['With Icons']),
-          h.div(
-            [h.Class('mx-auto w-full max-w-sm rounded-lg border p-3 text-sm')],
-            [h.p([], ['Command palette with icons and shortcuts.'])],
-          ),
+          h.Role('status'),
+          h.DataAttribute('command-result', ''),
+          h.Class('text-sm text-muted-foreground'),
+        ],
+        [
+          model.commandRunCount
+            ? `Ran ${model.lastCommand}. Commands run: ${model.commandRunCount}.`
+            : 'No command run yet.',
         ],
       ),
     ],
   )
 
-const fields = { commandSearch: S.String }
-
-const stateSchema = S.Struct(fields)
-type State = typeof stateSchema.Type
+// cmdk also leaves the global shortcut to its caller. Scope this demo to its page.
+export const subscriptions = Subscription.make<State, typeof Message.ToggledCommandDialog.Type>()(
+  (entry) => ({
+    commandShortcut: entry(
+      { enabled: S.Boolean },
+      {
+        modelToDependencies: () => ({ enabled: true }),
+        dependenciesToStream: () =>
+          Subscription.fromEventFilterMap<KeyboardEvent, typeof Message.ToggledCommandDialog.Type>({
+            target: window,
+            type: 'keydown',
+            toMessage: (event) => {
+              if (
+                window.location.pathname === '/docs/command' &&
+                !event.defaultPrevented &&
+                !event.isComposing &&
+                !event.repeat &&
+                (event.metaKey || event.ctrlKey) &&
+                event.key.toLowerCase() === 'k'
+              ) {
+                event.preventDefault()
+                return Option.some(Message.ToggledCommandDialog())
+              }
+              return Option.none()
+            },
+          }),
+      },
+    ),
+  }),
+)
 
 export const slice = defineSlice({
   fields,
-  init: { commandSearch: '' },
-  messages: [Message.UpdatedCommandSearch],
-  handlers: (model: State) => ({
-    UpdatedCommandSearch: ({ value }: typeof Message.UpdatedCommandSearch.Type): UpdateReturn => ({
-      model: evo(model, { commandSearch: () => value }),
+  init: {
+    inlineCommand: Command.init({ id: 'command-inline' }),
+    commandDialog: Command.CommandDialog.init({
+      id: 'command-demo',
+      closeOnSelect: true,
+      resetOnOpen: true,
     }),
+    lastCommand: '',
+    commandRunCount: 0,
+  },
+  messages: [
+    Message.GotInlineCommandMessage,
+    Message.GotCommandDialogMessage,
+    Message.ToggledCommandDialog,
+  ],
+  handlers: (model: State) => ({
+    GotInlineCommandMessage: ({
+      message,
+    }: typeof Message.GotInlineCommandMessage.Type): UpdateReturn => foldInline(model, message),
+    GotCommandDialogMessage: ({
+      message,
+    }: typeof Message.GotCommandDialogMessage.Type): UpdateReturn => foldDialog(model, message),
+    ToggledCommandDialog: (): UpdateReturn => {
+      const result = model.commandDialog.dialog.isOpen
+        ? Command.CommandDialog.close(model.commandDialog)
+        : Command.CommandDialog.open(model.commandDialog)
+      return {
+        model: { ...model, commandDialog: result.model },
+        commands: RuntimeCommand.mapMessages(result.commands ?? [], (message) =>
+          Message.GotCommandDialogMessage({ message }),
+        ),
+      }
+    },
   }),
-  samples: [Message.UpdatedCommandSearch({ value: 'cal' })],
+  samples: [Message.ToggledCommandDialog()],
+  subscriptions,
 })

--- a/packages/web/src/page/item.ts
+++ b/packages/web/src/page/item.ts
@@ -1,3 +1,4 @@
+import commandGuideUrl from '../../../../docs/command-composition.md?url'
 import { Option } from 'effect'
 import type { Html, HtmlBuilder } from 'foldkit/html'
 import { createLazy } from 'foldkit/html'
@@ -40,7 +41,21 @@ const gapsCallout = (name: string, h: HtmlBuilder<AppMessage>): Html => {
     [
       icon(h, TriangleAlert),
       Alert.title<AppMessage>({}, ['Differences vs shadcn/ui'], h),
-      Alert.description<AppMessage>({}, [h.ul([h.Class('list-disc space-y-1 pl-4')], gaps)], h),
+      Alert.description<AppMessage>(
+        {},
+        [
+          h.ul([h.Class('list-disc space-y-1 pl-4')], gaps),
+          ...(name === 'command'
+            ? [
+                h.a(
+                  [h.Href(commandGuideUrl), h.Class('underline underline-offset-4')],
+                  ['Read the Command and CommandDialog guide'],
+                ),
+              ]
+            : []),
+        ],
+        h,
+      ),
     ],
     h,
   )


### PR DESCRIPTION
Command previously supplied presentational markup without filtering or selection behavior. This adds a stateful inline palette and a composed CommandDialog: searching `clndr` matches Calendar, keyword aliases such as `payment` match Billing, and keyboard or pointer selection emits an application action.

Closes #21.

## Changes

- Add fuzzy ranking, grouped results, disabled and empty states, custom/external filtering, keyboard navigation, pointer activation, and IME protection. Stateful rows reuse `Command.item`.
- Compose Foldkit Dialog for modal focus and dismissal, with optional close-on-selection and reset-on-open. Global shortcuts remain application-owned.
- Preserve `cmdk-*` selectors in the shared resolver. Previously, selector stripping also erased Command's DOM queries. Add regression coverage across all nine generated styles.
- Include the adapted cmdk scorer as a separate source file with its upstream commit and MIT license preserved. The command registry item installs both files and its dependencies.
- Add inline/dialog demos, a rerunnable browser check, and a guide bundled with the showcase. Size check indicators explicitly to prevent oversized rows in Mira. Vendored CSS is unchanged.

## Validation

- Formatting, lint, typechecks, and all 30 tests passed; registry validation passed.
- Registry and production web builds passed. Verified the scorer and dependencies in all nine generated catalogs and the bundled guide against its source.
- Chrome interaction checks passed across all nine styles, including a 390px-wide Rhea viewport: fuzzy/alias filtering, navigation, groups, disabled/empty results, keyboard/pointer selection, IME, repeat actions, shortcuts, and focus restoration.
- Native Chrome confirmed dialog selection and focus restoration. The embedded preview did not reliably mount the runtime; the browser script now waits for mounting explicitly.

## Compatibility boundary

This is a data-driven Foldkit API, not a drop-in React cmdk API. It uses item arrays and Foldkit submodels rather than React child registration. Nested pages, asynchronous fetching, actions, and global shortcuts remain application-owned. Full visual or behavioral equivalence with cmdk is not claimed.

The existing pre-push hook runs build and typecheck concurrently. The first push attempt hit an `ENOENT` while both regenerated shared style directories; the separate build checks above passed. This hook configuration is unchanged by the PR.
