### PR TITLE
demo(dialog): add working scrollable dialog demo

### DIFF
--- a/packages/web/src/demo/views/dialog.ts
+++ b/packages/web/src/demo/views/dialog.ts
@@ -26,10 +26,14 @@ const DialogSizeLabel: Record<DialogSize, string> = {
   lg: 'Large',
 }
 
+const DialogContent = S.Literals(['form', 'scroll'])
+type DialogContent = typeof DialogContent.Type
+
 const Message = defineMessageUnion({
   GotDialogMessage: { message: Dialog.Message },
-  ClickedOpenDialog: {},
+  ClickedOpenBasicDialog: {},
   ClickedOpenSizedDialog: { size: DialogSize },
+  ClickedOpenScrollableDialog: {},
 })
 
 export const dialogView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
@@ -44,7 +48,7 @@ export const dialogView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
             [h.Class('flex flex-col items-start gap-4')],
             [
               button<AppMessage>(
-                { variant: 'outline', onClick: Message.ClickedOpenDialog() },
+                { variant: 'outline', onClick: Message.ClickedOpenBasicDialog() },
                 'Open Dialog',
                 h,
               ),
@@ -55,96 +59,200 @@ export const dialogView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
                 viewInputs: Dialog.styledViewInputs(
                   {
                     panelClass: DialogSizePanelClass[model.dialogSize],
-                    content: ({ closeButton, title, description }, h) => [
-                      Dialog.header(
-                        {},
-                        [
-                          Dialog.title(
-                            { attributes: title },
-                            ['Edit profile (', DialogSizeLabel[model.dialogSize], ')'],
-                            h,
-                          ),
-                          Dialog.description(
-                            { attributes: description },
-                            ['Make changes to your profile here. Click save when you are done.'],
-                            h,
-                          ),
-                        ],
-                        h,
-                      ),
-                      h.div(
-                        [h.Class('grid gap-4 py-4')],
-                        [
-                          h.div(
-                            [h.Class('grid gap-3')],
-                            [
-                              h.label(
-                                [
-                                  h.Class(
-                                    'flex items-center gap-2 text-sm leading-none font-medium',
-                                  ),
-                                  h.For('dialog-name-1'),
-                                ],
-                                ['Name'],
-                              ),
-                              h.input([
-                                h.Class(
-                                  'flex h-8 w-full rounded-lg border border-input bg-transparent px-3 py-1 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50',
+                    content: ({ closeButton, title, description }, h) =>
+                      model.dialogContent === 'scroll'
+                        ? [
+                            Dialog.header(
+                              {},
+                              [
+                                Dialog.title({ attributes: title }, ['Scrollable dialog'], h),
+                                Dialog.description(
+                                  { attributes: description },
+                                  ['Long content scrolls inside the dialog body.'],
+                                  h,
                                 ),
-                                h.Id('dialog-name-1'),
-                                h.Attribute('name', 'name'),
-                                h.Attribute('defaultValue', 'Pedro Duarte'),
-                              ]),
-                            ],
-                          ),
-                          h.div(
-                            [h.Class('grid gap-3')],
-                            [
-                              h.label(
-                                [
-                                  h.Class(
-                                    'flex items-center gap-2 text-sm leading-none font-medium',
-                                  ),
-                                  h.For('dialog-username-1'),
-                                ],
-                                ['Username'],
-                              ),
-                              h.input([
+                              ],
+                              h,
+                            ),
+                            h.div(
+                              [
                                 h.Class(
-                                  'flex h-8 w-full rounded-lg border border-input bg-transparent px-3 py-1 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50',
+                                  'max-h-[40vh] space-y-4 overflow-y-auto px-1 py-4 text-sm leading-relaxed',
                                 ),
-                                h.Id('dialog-username-1'),
-                                h.Attribute('name', 'username'),
-                                h.Attribute('defaultValue', '@peduarte'),
-                              ]),
-                            ],
-                          ),
-                        ],
-                      ),
-                      Dialog.footer(
-                        {},
-                        [
-                          h.button(
-                            [
-                              ...closeButton,
-                              h.Class(
-                                'inline-flex h-8 items-center justify-center rounded-lg border border-input bg-background px-3 text-sm font-medium hover:bg-accent hover:text-accent-foreground',
-                              ),
-                            ],
-                            ['Cancel'],
-                          ),
-                          h.button(
-                            [
-                              h.Class(
-                                'inline-flex h-8 items-center justify-center rounded-lg bg-primary px-3 text-sm font-medium text-primary-foreground hover:bg-primary/90',
-                              ),
-                            ],
-                            ['Save changes'],
-                          ),
-                        ],
-                        h,
-                      ),
-                    ],
+                              ],
+                              [
+                                h.p(
+                                  [],
+                                  [
+                                    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+                                  ],
+                                ),
+                                h.p(
+                                  [],
+                                  [
+                                    'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+                                  ],
+                                ),
+                                h.p(
+                                  [],
+                                  [
+                                    'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
+                                  ],
+                                ),
+                                h.p(
+                                  [],
+                                  [
+                                    'Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+                                  ],
+                                ),
+                                h.p(
+                                  [],
+                                  [
+                                    'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.',
+                                  ],
+                                ),
+                                h.p(
+                                  [],
+                                  [
+                                    'Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni.',
+                                  ],
+                                ),
+                                h.p(
+                                  [],
+                                  [
+                                    'Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit.',
+                                  ],
+                                ),
+                                h.p(
+                                  [],
+                                  [
+                                    'Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam.',
+                                  ],
+                                ),
+                                h.p(
+                                  [],
+                                  [
+                                    'Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur.',
+                                  ],
+                                ),
+                              ],
+                            ),
+                            Dialog.footer(
+                              {},
+                              [
+                                h.button(
+                                  [
+                                    ...closeButton,
+                                    h.Class(
+                                      'inline-flex h-8 items-center justify-center rounded-lg border border-input bg-background px-3 text-sm font-medium hover:bg-accent hover:text-accent-foreground',
+                                    ),
+                                  ],
+                                  ['Cancel'],
+                                ),
+                                h.button(
+                                  [
+                                    h.Class(
+                                      'inline-flex h-8 items-center justify-center rounded-lg bg-primary px-3 text-sm font-medium text-primary-foreground hover:bg-primary/90',
+                                    ),
+                                  ],
+                                  ['Done'],
+                                ),
+                              ],
+                              h,
+                            ),
+                          ]
+                        : [
+                            Dialog.header(
+                              {},
+                              [
+                                Dialog.title(
+                                  { attributes: title },
+                                  ['Edit profile (', DialogSizeLabel[model.dialogSize], ')'],
+                                  h,
+                                ),
+                                Dialog.description(
+                                  { attributes: description },
+                                  [
+                                    'Make changes to your profile here. Click save when you are done.',
+                                  ],
+                                  h,
+                                ),
+                              ],
+                              h,
+                            ),
+                            h.div(
+                              [h.Class('grid gap-4 py-4')],
+                              [
+                                h.div(
+                                  [h.Class('grid gap-3')],
+                                  [
+                                    h.label(
+                                      [
+                                        h.Class(
+                                          'flex items-center gap-2 text-sm leading-none font-medium',
+                                        ),
+                                        h.For('dialog-name-1'),
+                                      ],
+                                      ['Name'],
+                                    ),
+                                    h.input([
+                                      h.Class(
+                                        'flex h-8 w-full rounded-lg border border-input bg-transparent px-3 py-1 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50',
+                                      ),
+                                      h.Id('dialog-name-1'),
+                                      h.Attribute('name', 'name'),
+                                      h.Attribute('defaultValue', 'Pedro Duarte'),
+                                    ]),
+                                  ],
+                                ),
+                                h.div(
+                                  [h.Class('grid gap-3')],
+                                  [
+                                    h.label(
+                                      [
+                                        h.Class(
+                                          'flex items-center gap-2 text-sm leading-none font-medium',
+                                        ),
+                                        h.For('dialog-username-1'),
+                                      ],
+                                      ['Username'],
+                                    ),
+                                    h.input([
+                                      h.Class(
+                                        'flex h-8 w-full rounded-lg border border-input bg-transparent px-3 py-1 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50',
+                                      ),
+                                      h.Id('dialog-username-1'),
+                                      h.Attribute('name', 'username'),
+                                      h.Attribute('defaultValue', '@peduarte'),
+                                    ]),
+                                  ],
+                                ),
+                              ],
+                            ),
+                            Dialog.footer(
+                              {},
+                              [
+                                h.button(
+                                  [
+                                    ...closeButton,
+                                    h.Class(
+                                      'inline-flex h-8 items-center justify-center rounded-lg border border-input bg-background px-3 text-sm font-medium hover:bg-accent hover:text-accent-foreground',
+                                    ),
+                                  ],
+                                  ['Cancel'],
+                                ),
+                                h.button(
+                                  [
+                                    h.Class(
+                                      'inline-flex h-8 items-center justify-center rounded-lg bg-primary px-3 text-sm font-medium text-primary-foreground hover:bg-primary/90',
+                                    ),
+                                  ],
+                                  ['Save changes'],
+                                ),
+                              ],
+                              h,
+                            ),
+                          ],
                   },
                   h,
                 ),
@@ -159,8 +267,18 @@ export const dialogView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
         [
           h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], ['With Scroll']),
           h.div(
-            [h.Class('mx-auto w-full max-w-sm rounded-lg border p-4 text-sm')],
-            [h.p([], ['Dialog with scrollable content — long content scrolls inside the dialog.'])],
+            [h.Class('flex flex-col items-start gap-4')],
+            [
+              button<AppMessage>(
+                { variant: 'outline', onClick: Message.ClickedOpenScrollableDialog() },
+                'Open Scrollable Dialog',
+                h,
+              ),
+              h.p(
+                [h.Class('px-1 text-xs text-muted-foreground')],
+                ['Long content scrolls inside the dialog body.'],
+              ),
+            ],
           ),
         ],
       ),
@@ -215,35 +333,56 @@ const foldDialog = Update.foldChild({
   foldOutMessage: foldDialogOutMessage,
 })
 
-const fields = { dialog: Dialog.Model, dialogSize: DialogSize }
+const fields = { dialog: Dialog.Model, dialogSize: DialogSize, dialogContent: DialogContent }
 
 const stateSchema = S.Struct(fields)
 type State = typeof stateSchema.Type
 
 export const slice = defineSlice({
   fields,
-  init: { dialog: Dialog.init({ id: 'dialog-demo' }), dialogSize: 'default' },
-  messages: [Message.GotDialogMessage, Message.ClickedOpenDialog, Message.ClickedOpenSizedDialog],
+  init: {
+    dialog: Dialog.init({ id: 'dialog-demo' }),
+    dialogSize: 'default',
+    dialogContent: 'form',
+  },
+  messages: [
+    Message.GotDialogMessage,
+    Message.ClickedOpenBasicDialog,
+    Message.ClickedOpenSizedDialog,
+    Message.ClickedOpenScrollableDialog,
+  ],
   handlers: (model: State) => ({
     GotDialogMessage: (payload: typeof Message.GotDialogMessage.Type): UpdateReturn =>
       foldDialog(model, payload.message),
-    ClickedOpenDialog: (): UpdateReturn => {
-      const { model: next, commands = [] } = Dialog.open(model.dialog)
+    ClickedOpenBasicDialog: (): UpdateReturn => {
+      const formed = evo(model, { dialogContent: () => 'form' as const })
+      const { model: next, commands = [] } = Dialog.open(formed.dialog)
       return {
-        model: evo(model, { dialog: () => next }),
+        model: evo(formed, { dialog: () => next }),
         commands: Command.mapMessages(commands, (message) => Message.GotDialogMessage({ message })),
       }
     },
     ClickedOpenSizedDialog: ({
       size,
     }: typeof Message.ClickedOpenSizedDialog.Type): UpdateReturn => {
-      const sized = evo(model, { dialogSize: () => size })
+      const sized = evo(model, { dialogSize: () => size, dialogContent: () => 'form' as const })
       const { model: next, commands = [] } = Dialog.open(sized.dialog)
       return {
         model: evo(sized, { dialog: () => next }),
         commands: Command.mapMessages(commands, (message) => Message.GotDialogMessage({ message })),
       }
     },
+    ClickedOpenScrollableDialog: (): UpdateReturn => {
+      const scrolled = evo(model, {
+        dialogContent: () => 'scroll' as const,
+        dialogSize: () => 'default' as const,
+      })
+      const { model: next, commands = [] } = Dialog.open(scrolled.dialog)
+      return {
+        model: evo(scrolled, { dialog: () => next }),
+        commands: Command.mapMessages(commands, (message) => Message.GotDialogMessage({ message })),
+      }
+    },
   }),
-  samples: [Message.ClickedOpenDialog(), Message.ClickedOpenSizedDialog({ size: 'lg' })],
+  samples: [Message.ClickedOpenBasicDialog(), Message.ClickedOpenSizedDialog({ size: 'lg' })],
 })


### PR DESCRIPTION
The With Scroll section was a static placeholder box. It now opens a real dialog with a fixed header, a scrolling lorem body, and a fixed Cancel and Done footer.

The Basic open path moves to ClickedOpenBasicDialog. ClickedOpenDialog is shared with the alert dialog, drawer, and sheet slices, and the sheet handler wins the assemble spread, so the dialog slice handler never ran and Basic kept showing stale scroll content after a scroll open.

Verified with tsc, oxlint, registry build, and the real page in a browser. Basic, Sizes, and Scrollable each show the right content, including scroll then Basic.