### PR TITLE
drag-and-drop: build classes on Item and Card tokens

### DIFF
--- a/packages/registry/registry/default/ui/drag-and-drop.ts
+++ b/packages/registry/registry/default/ui/drag-and-drop.ts
@@ -34,25 +34,14 @@ export type InitConfig = FoldkitDragAndDrop.InitConfig
 export type DraggableConfig<M> = FoldkitDragAndDrop.DraggableConfig<M>
 export type DraggableMessage = FoldkitDragAndDrop.DraggableMessage
 
-// Card-like draggable item. Mirrors shadcn card/list-item styling:
-// `border bg-card text-card-foreground shadow-xs` with
-// `focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50`
-// since `draggable` emits `tabindex=0` + `role=option` (focusable). The
-// submodel's `touch-action: none` / `user-select: none` inline styles are
-// complemented here with `select-none` + `cursor-grab`. Set
-// `data-dragging` on the element when `isDragging` / `maybeDraggedItemId`
-// indicates this item is being dragged — the `data-[dragging]:opacity-50`
-// hook dims the source. Keyboard dragging is covered by `focus-visible`
-// rather than a separate `data-[keyboard-dragging]` attribute (the submodel
-// never emits that).
 export const dragCardClass =
-  'flex items-center gap-2 rounded-lg border bg-card px-3 py-2 text-sm text-card-foreground shadow-xs outline-none select-none transition-colors focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 data-[dragging]:opacity-50 cursor-grab active:cursor-grabbing'
+  'cn-item cn-item-variant-outline cn-item-size-default cursor-grab select-none bg-card text-card-foreground shadow-xs data-[dragging]:opacity-50 active:cursor-grabbing'
 
 export const dragDropPlaceholderClass =
-  'h-9 rounded-lg border-2 border-dashed border-primary/50 bg-primary/5'
+  'cn-item h-9 border-2 border-dashed border-primary/50 bg-primary/5'
 
 export const dragContainerClass =
-  'flex min-h-[120px] flex-col gap-1.5 rounded-lg border-2 border-transparent bg-muted/50 p-2 outline-none transition-colors focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 data-[drop-target]:border-dashed data-[drop-target]:border-primary/50 data-[drop-target]:bg-accent/50'
+  'cn-card flex min-h-[120px] flex-col gap-1.5 border-2 border-transparent bg-muted/50 p-2 outline-none transition-colors focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 data-[drop-target]:border-dashed data-[drop-target]:border-primary/50 data-[drop-target]:bg-accent/50'
 
 export const dragGhostClass =
-  'flex items-center gap-2 rounded-lg border bg-card px-3 py-2 text-sm text-card-foreground shadow-lg ring-1 ring-foreground/10 select-none'
+  'cn-item cn-item-variant-outline cn-item-size-default bg-card text-card-foreground shadow-lg ring-1 ring-foreground/10 select-none'

--- a/packages/web/src/demo/views/drag-and-drop.ts
+++ b/packages/web/src/demo/views/drag-and-drop.ts
@@ -5,7 +5,6 @@ import { evo } from 'foldkit/struct'
 import { defineMessageUnion } from 'foldkit/message'
 import type { Html, HtmlBuilder } from 'foldkit/html'
 
-import { cn } from '../../generated/registry/lib/utils'
 import * as DragAndDrop from '../../generated/registry/ui/drag-and-drop'
 
 import { defineSlice, type UpdateReturn } from '../slice'
@@ -82,19 +81,13 @@ const cardView = (
 ): Html => {
   const maybeItemId = DragAndDrop.maybeDraggedItemId(model.dragAndDrop)
   const isBeingDragged = Option.exists(maybeItemId, (id) => id === card.id)
-  const isKeyboardDragged =
-    isBeingDragged && model.dragAndDrop.dragState._tag === 'KeyboardDragging'
   const isPointerDragged = isBeingDragged && model.dragAndDrop.dragState._tag === 'Dragging'
 
   return h.keyed('div')(
     card.id,
     [
-      h.Class(
-        cn(DragAndDrop.dragCardClass, {
-          'opacity-40': isPointerDragged,
-          'data-[keyboard-dragging]': isKeyboardDragged,
-        }),
-      ),
+      h.Class(DragAndDrop.dragCardClass),
+      ...(isPointerDragged ? [h.DataAttribute('dragging', '')] : []),
       ...DragAndDrop.draggable(
         {
           model: model.dragAndDrop,
@@ -135,11 +128,8 @@ const renderColumn = (
       ),
       h.div(
         [
-          h.Class(
-            cn(DragAndDrop.dragContainerClass, {
-              'border-dashed !border-primary/50': isDropTarget,
-            }),
-          ),
+          h.Class(DragAndDrop.dragContainerClass),
+          ...(isDropTarget ? [h.DataAttribute('drop-target', '')] : []),
           ...DragAndDrop.droppable(column.id, column.label),
         ],
         [...children],


### PR DESCRIPTION
Raw Tailwind in the drag classes gave resolve nothing to substitute, so every style shipped identical output. I confirmed it by diffing the resolved default and lyra trees.

Cards, ghost, and placeholder now compose cn-item, cn-item-variant-outline, and cn-item-size-default. The container composes cn-card. Tails keep only interaction concerns.

The demo sets data-dragging and data-drop-target so the hooks match. This replaces the opacity override and the important-prefixed border override. The dead keyboard-dragging class is gone.

Resolved default vs lyra now differ (rounded-lg/text-sm against rounded-none/text-xs, rounded-xl against rounded-none container). Registry build passes. Web typecheck and full build pass. Web tests sit at 29/30, with the command-behavior timeout failing on the clean tree too.