### PR TITLE
fix(input-otp): keep the update channel alive at completion

### DIFF
--- a/docs/shadcn-base-parity-audit.md
+++ b/docs/shadcn-base-parity-audit.md
@@ -13,7 +13,11 @@
 > #1 button disabled → `aria-disabled:`/`data-disabled:` twins added in `packages/registry/registry/default/style/cn-compat.css` (button block);
 > #2 progress indeterminate → `undefined` now renders an empty track (`packages/registry/registry/default/ui/progress.ts`; animated indeterminate still awaits primitive support);
 > #3 switch hidden input → Foldkit's `attributes.hiddenInput` is now rendered (`packages/registry/registry/default/ui/switch.ts`);
-> #4 input-otp `onComplete` → documented intentional update-channel fallback with an in-code comment (`packages/registry/registry/default/ui/input-otp.ts`).
+> #4 input-otp `onComplete` → fixed: `onInput` now fires on every change
+> including the completing one (mirrors upstream `onChange`); `onComplete`
+> alone remains the update channel when `onInput` is absent, and Group/Slot
+> parts plus `isInvalid` landed (`packages/registry/registry/default/ui/input-otp.ts`).
+> Remaining: numeric-only (no pattern/alphanumeric mode).
 > Gaps #5–#12 are unchanged.
 >
 > **Menu update (2026-09-03):** menu/context-menu/menubar panels now emit
@@ -44,11 +48,11 @@ Beyond styling, several foldcn components are missing their **defining behaviors
 
 ## Scorecard (52 compared pairs)
 
-| Verdict     | Count | Components                                                                                                                                                                                                                                                                                                    |
-| ----------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| MATCHES     | 4     | label, separator, spinner, kbd                                                                                                                                                                                                                                                                                |
-| MINOR DIFFS | 18    | input, textarea, checkbox, avatar, card, skeleton, popover, tooltip, tabs, breadcrumb, toggle, item, fieldset↔field, slider, aspect-ratio, direction, marker, table                                                                                                                                           |
-| MAJOR DIFFS | 30    | button, switch, radio-group, select, menu, context-menu, menubar, combobox, command, dialog, alert-dialog, sheet, drawer, hover-card, accordion, collapsible, navigation-menu, toggle-group, alert, badge, empty, progress, input-group, input-otp, button-group, calendar, resizable, sonner, toast, sidebar |
+| Verdict     | Count | Components                                                                                                                                                                                                                                                                                         |
+| ----------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| MATCHES     | 4     | label, separator, spinner, kbd                                                                                                                                                                                                                                                                     |
+| MINOR DIFFS | 19    | input, textarea, checkbox, avatar, card, skeleton, popover, tooltip, tabs, breadcrumb, toggle, item, fieldset↔field, slider, aspect-ratio, direction, marker, table, input-otp                                                                                                                     |
+| MAJOR DIFFS | 29    | button, switch, radio-group, select, menu, context-menu, menubar, combobox, command, dialog, alert-dialog, sheet, drawer, hover-card, accordion, collapsible, navigation-menu, toggle-group, alert, badge, empty, progress, input-group, button-group, calendar, resizable, sonner, toast, sidebar |
 
 ### Not covered (no counterpart)
 
@@ -62,7 +66,12 @@ Beyond styling, several foldcn components are missing their **defining behaviors
 1. **button — disabled is visually broken.** Foldkit emits `aria-disabled="true"` + `data-disabled=""` (never native `disabled`), but foldcn ships only `disabled:pointer-events-none disabled:opacity-50`. The `:disabled` pseudo-class never matches → disabled buttons look enabled and stay tabbable (`tabindex="0"` always emitted).
 2. **progress — indeterminate renders a full bar.** `value === undefined` applies no transform; indicator is `w-full` → 100%. Legacy used `100 - (value || 0)`; base primitive has true indeterminate. Also no `role="progressbar"`/ARIA values, no Label/Value parts.
 3. **switch — form payload dropped.** Config accepts `name`/`value` but `toView` never renders the hidden input Foldkit supplies (checkbox does) → nothing submits.
-4. **input-otp — `onComplete` fires on partial values** when `onInput` is absent (fall-through at the end of the `OnInput` handler).
+4. **input-otp — numeric-only + single-message callbacks.** Non-digits are
+   stripped with no `pattern`/alphanumeric mode like upstream, and foldkit
+   maps one event to one message: `onInput` fires on every change (including
+   completion) while `onComplete` alone doubles as the update channel — the
+   two never fire for the same keystroke, so controlled owners derive
+   completion from their stored value.
 5. **hover-card — click-toggled, not hover.** It reuses the Popover submodel; there is no hover-intent delay/grace model. Trigger semantics are the component's defining behavior.
 6. **context-menu — not a context menu.** Opens on activation at a fixed anchor; no right-click/pointer-position anchoring.
 7. **menubar — no menubar behavior.** Each trigger is an independent Menu bundle; no ArrowLeft/Right traversal, no open-on-hover-of-next-trigger.
@@ -134,7 +143,7 @@ Beyond styling, several foldcn components are missing their **defining behaviors
 ### Composite inputs
 
 - **input-group — MINOR.** Full part set (Group/Addon/Button/Text/Input/Textarea) with `role=group`, align variants, and frame-level invalid/focus states keyed off `data-slot=input-group-control`; addon-click-focus missing (foldkit has no scoped click-to-focus attribute).
-- **input-otp — MAJOR.** Standalone cells vs joined pill; no Group/Slot/Separator parts; onComplete quirk (bug #4).
+- **input-otp — MINOR.** Full part set (root/Group/Slot/Separator) with joined-pill slots, active caret, and invalid rings; numeric-only with no pattern/alphanumeric mode, and one-message-per-event callbacks (see bug #4).
 - **button-group — MAJOR.** Outer-frame model vs child corner-cutting; no orientation/Text/Separator, no `role=group`.
 - **item — MINOR.** Full part parity minus `xs` size; padding/radius/hover drift; media boxed vs bare.
 - **fieldset ↔ field — MINOR.** Near-complete part mapping incl. container-query responsive orientation; spacing drift; checked-label card tint/radius differ.

--- a/packages/registry/registry/default/ui/input-otp.ts
+++ b/packages/registry/registry/default/ui/input-otp.ts
@@ -2,18 +2,57 @@ import type { Html, HtmlBuilder } from 'foldkit/html'
 
 import { cn } from '@/lib/utils'
 
+type Child = Html | string
+
 // InputOtp renders one transparent <input> overlaid across a row of visual
 // slots. Every keystroke lands in that single input, so the browser handles
 // the hard parts natively — auto-advancing as digits are typed, stepping back
 // on Backspace, arrow-key navigation, and pasting a full code into the slots —
 // the way shadcn's `input-otp` base surface does through the `input-otp`
 // library. The slots are purely presentational: each shows one character of
-// `value`, and the active (next-to-fill) slot shows a blinking caret.
+// `value`, and the next-to-fill slot shows a blinking caret.
+//
+// The dependency-free helpers below (`normalizeOtpValue`,
+// `isCompleteOtpValue`, `otpSlotStates`) are the headless core: they own
+// every domain rule with no foldkit import, so they can move verbatim into a
+// future `@foldkit/ui` OTP primitive while this file keeps the styled parts.
+
+/** Digits-only value capped at `length`. Mirrors the numeric-OTP demos: every
+ *  keystroke, paste, or autofill is reduced to this before it reaches slots
+ *  or callbacks. */
+export const normalizeOtpValue = (raw: string, length: number): string =>
+  raw.replace(/\D/g, '').slice(0, length)
+
+/** A normalized value fills every slot. Owners derive completion from their
+ *  stored value with this instead of a second callback. */
+export const isCompleteOtpValue = (value: string, length: number): boolean =>
+  normalizeOtpValue(value, length).length >= length
+
+/** Per-slot render state, always `length` long. Exactly one slot is active
+ *  (the insert position) until the code is complete, when none is — the same
+ *  rule the `input-otp` library's `hasFakeCaret` follows. */
+export type OtpSlotState = Readonly<{
+  index: number
+  char: string | null
+  isActive: boolean
+}>
+
+export const otpSlotStates = (value: string, length: number): ReadonlyArray<OtpSlotState> => {
+  const digits = normalizeOtpValue(value, length).split('')
+  const activeIndex = digits.length >= length ? -1 : digits.length
+  return Array.from({ length }, (_, index) => ({
+    index,
+    char: digits[index] ?? null,
+    isActive: index === activeIndex,
+  }))
+}
 
 export const inputOtpClass = 'cn-input-otp flex items-center has-disabled:opacity-50'
 
-/** Wrapper grouping the joined slots; keys the group's invalid ring off the
- *  input's aria-invalid. */
+/** Wrapper grouping the joined slots. Upstream keys the group's invalid ring
+ *  off descendant `aria-invalid` (`has-aria-invalid:`), which the default
+ *  layout threads onto every slot via `isInvalid`; custom `children`
+ *  layouts must pass `isInvalid` to their own slots for the ring to light. */
 export const inputOtpGroupClass = 'cn-input-otp-group flex items-center'
 
 export const inputOtpInputClass = 'cn-input-otp-input disabled:cursor-not-allowed'
@@ -34,8 +73,11 @@ export type InputOtpConfig<M> = Readonly<{
   onInput?: (value: string) => M
   onComplete?: (value: string) => M
   isDisabled?: boolean
+  isInvalid?: boolean
   autoFocus?: boolean
+  id?: string
   className?: string
+  children?: ReadonlyArray<Child>
 }>
 
 /** Visual separator between OTP groups (e.g. between groups of 3). Upstream
@@ -55,28 +97,67 @@ export const inputOtpSeparator = <M>(
     ['−'],
   )
 
+/** One visual slot. The parent owns the code string and passes it down with
+ *  the slot's `index` — the same information upstream's `OTPInputContext`
+ *  carries, without framework context. */
+export type InputOtpSlotConfig = Readonly<{
+  index: number
+  value: string
+  length: number
+  isInvalid?: boolean
+  className?: string
+}>
+
+export const inputOtpSlot = <M>(config: InputOtpSlotConfig, h: HtmlBuilder<M>): Html => {
+  const state = otpSlotStates(config.value, config.length)[config.index] ?? {
+    index: config.index,
+    char: null,
+    isActive: false,
+  }
+  return h.div(
+    [
+      h.Class(cn(inputOtpSlotClass, config.className)),
+      h.DataAttribute('slot', 'input-otp-slot'),
+      h.DataAttribute('active', state.isActive ? 'true' : 'false'),
+      ...(config.isInvalid === true ? [h.AriaInvalid(true)] : []),
+    ],
+    [
+      state.char ?? '',
+      state.isActive
+        ? h.div([h.Class(inputOtpCaretClass)], [h.div([h.Class(inputOtpCaretLineClass)], [])])
+        : null,
+    ],
+  )
+}
+
+/** A row of joined slots. Pass slots (and separators between groups) as
+ *  children to compose multi-group layouts like upstream's separator demo. */
+export const inputOtpGroup = <M>(
+  config: Readonly<{ className?: string }>,
+  children: ReadonlyArray<Child>,
+  h: HtmlBuilder<M>,
+): Html =>
+  h.div(
+    [h.Class(cn(inputOtpGroupClass, config.className)), h.DataAttribute('slot', 'input-otp-group')],
+    children,
+  )
+
 /** A row of single-character OTP slots backed by one combined string `value`.
  *  Digit-only filtering is intentional (mirrors upstream numeric OTP):
- *  non-digits are stripped on display and on input. */
+ *  non-digits are stripped on display and on input.
+ *
+ *  `onInput` is the update channel and fires on every change, including the
+ *  completing one (mirrors upstream `onChange`). With no `onInput`,
+ *  `onComplete` doubles as the update channel and fires on every change —
+ *  check `isCompleteOtpValue(next, length)` before treating it as
+ *  completion. Controlled owners observe completion from their stored value;
+ *  foldkit maps one event to one message, so the two callbacks never fire
+ *  for the same keystroke.
+ *
+ *  Pass `children` (groups interleaved with separators) for multi-group
+ *  layouts; omit it for the default single group of `length` slots. */
 export const inputOtp = <M>(config: InputOtpConfig<M>, h: HtmlBuilder<M>): Html => {
-  const digits = config.value.replace(/\D/g, '').slice(0, config.length).split('')
-  const isComplete = digits.length >= config.length
-  const activeIndex = isComplete ? -1 : digits.length
-
-  const slot = (index: number): Html =>
-    h.div(
-      [
-        h.Class(inputOtpSlotClass),
-        h.DataAttribute('slot', 'input-otp-slot'),
-        ...(index === activeIndex ? [h.DataAttribute('active', 'true')] : []),
-      ],
-      [
-        digits[index] ?? '',
-        index === activeIndex
-          ? h.div([h.Class(inputOtpCaretClass)], [h.div([h.Class(inputOtpCaretLineClass)], [])])
-          : null,
-      ],
-    )
+  const value = normalizeOtpValue(config.value, config.length)
 
   return h.div(
     [h.Class(cn(inputOtpClass, config.className)), h.DataAttribute('slot', 'input-otp')],
@@ -85,35 +166,47 @@ export const inputOtp = <M>(config: InputOtpConfig<M>, h: HtmlBuilder<M>): Html 
         h.Type('text'),
         h.InputMode('numeric'),
         h.Attribute('autocomplete', 'one-time-code'),
-        h.Maxlength(config.length),
+        // No native maxlength: pasting a spaced/dashed code must reach the
+        // handler whole so `normalizeOtpValue` strips separators before
+        // capping at `length`. Over-length typing collapses back to the
+        // normalized value on re-render.
         h.Spellcheck(false),
         ...(config.isDisabled === true ? [h.Disabled(true)] : []),
+        ...(config.isInvalid === true ? [h.AriaInvalid(true)] : []),
         ...(config.autoFocus === true ? [h.Autofocus(true)] : []),
-        h.Value(digits.join('')),
+        ...(config.id === undefined ? [] : [h.Id(config.id)]),
+        h.Value(value),
         h.Class(inputOtpInputClass),
         h.DataAttribute('slot', 'input-otp-input'),
         ...(config.onInput === undefined && config.onComplete === undefined
           ? []
           : [
               h.OnInput((raw) => {
-                const next = raw.replace(/\D/g, '').slice(0, config.length)
-                if (config.onComplete !== undefined && next.length === config.length) {
-                  return config.onComplete(next)
-                }
+                const next = normalizeOtpValue(raw, config.length)
                 if (config.onInput !== undefined) {
                   return config.onInput(next)
                 }
-                // Only onComplete was provided: it doubles as the update
-                // channel for this controlled input, so it fires on every
-                // change (check `length` before treating it as completion).
-                return config.onComplete!(next)
+                if (config.onComplete !== undefined) {
+                  return config.onComplete(next)
+                }
+                throw new Error('unreachable: OnInput is only attached with a callback')
               }),
             ]),
       ]),
-      h.div(
-        [h.Class(cn(inputOtpGroupClass)), h.DataAttribute('slot', 'input-otp-group')],
-        Array.from({ length: config.length }, (_, index) => slot(index)),
-      ),
+      ...(config.children === undefined
+        ? [
+            inputOtpGroup<M>(
+              {},
+              Array.from({ length: config.length }, (_, index) =>
+                inputOtpSlot(
+                  { index, value, length: config.length, isInvalid: config.isInvalid },
+                  h,
+                ),
+              ),
+              h,
+            ),
+          ]
+        : config.children),
     ],
   )
 }

--- a/packages/web/src/catalog/gaps.ts
+++ b/packages/web/src/catalog/gaps.ts
@@ -41,6 +41,10 @@ export const gapsByItem = {
   progress: [
     'Indeterminate state renders an empty track — animated indeterminacy awaits primitive support.',
   ],
+  'input-otp': [
+    'Numeric codes only — non-digits are stripped with no pattern or alphanumeric mode like upstream.',
+    'onInput fires on every change; onComplete alone doubles as the update channel, so derive completion from the stored value.',
+  ],
 } as const
 
 const isGapItem = (name: string): name is keyof typeof gapsByItem => name in gapsByItem

--- a/packages/web/src/demo/views/input-otp.ts
+++ b/packages/web/src/demo/views/input-otp.ts
@@ -5,10 +5,9 @@ import type { Html, HtmlBuilder } from 'foldkit/html'
 
 import {
   inputOtp,
-  inputOtpGroupClass,
-  inputOtpSlotClass,
+  inputOtpGroup,
+  inputOtpSlot,
   inputOtpSeparator,
-  inputOtpClass,
 } from '../../generated/registry/ui/input-otp'
 import {
   field,
@@ -25,29 +24,35 @@ import type { Model, Message as AppMessage } from '../assemble'
 
 const Message = defineMessageUnion({
   UpdatedOtp: { value: S.String },
+  UpdatedSeparatedOtp: { value: S.String },
+  UpdatedFourOtp: { value: S.String },
+  UpdatedControlledOtp: { value: S.String },
+  UpdatedInvalidOtp: { value: S.String },
 })
 
-const otpSlots = (
+const separatedGroups = (
   h: HtmlBuilder<AppMessage>,
-  length: number,
   value: string,
-  highlightInvalid = false,
-): Html => {
-  const digits = value.replace(/\D/g, '').slice(0, length).split('')
-  return h.div(
-    [h.Class(inputOtpGroupClass), h.DataAttribute('slot', 'input-otp-group')],
-    Array.from({ length }, (_, i) =>
-      h.div(
-        [
-          h.Class(inputOtpSlotClass),
-          h.DataAttribute('slot', 'input-otp-slot'),
-          ...(highlightInvalid ? [h.AriaInvalid(true)] : []),
-        ],
-        [digits[i] ?? ''],
-      ),
-    ),
-  )
-}
+  isInvalid = false,
+): ReadonlyArray<Html> => [
+  inputOtpGroup<AppMessage>(
+    {},
+    [0, 1].map((index) => inputOtpSlot({ index, value, length: 6, isInvalid }, h)),
+    h,
+  ),
+  inputOtpSeparator({}, h),
+  inputOtpGroup<AppMessage>(
+    {},
+    [2, 3].map((index) => inputOtpSlot({ index, value, length: 6, isInvalid }, h)),
+    h,
+  ),
+  inputOtpSeparator({}, h),
+  inputOtpGroup<AppMessage>(
+    {},
+    [4, 5].map((index) => inputOtpSlot({ index, value, length: 6, isInvalid }, h)),
+    h,
+  ),
+]
 
 export const inputOtpView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
   h.div(
@@ -60,15 +65,15 @@ export const inputOtpView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
           field<AppMessage>(
             {},
             [
-              fieldLabel<AppMessage>({ for: 'simple' }, ['Simple'], h),
-              h.div(
-                [h.Class(inputOtpClass), h.DataAttribute('slot', 'input-otp')],
-                [
-                  h.div(
-                    [h.Class('flex items-center gap-2')],
-                    [otpSlots(h, 3, ''), inputOtpSeparator({}, h), otpSlots(h, 3, '')],
-                  ),
-                ],
+              fieldLabel<AppMessage>({ for: 'otp-simple' }, ['Simple'], h),
+              inputOtp<AppMessage>(
+                {
+                  length: 6,
+                  value: model.otp,
+                  id: 'otp-simple',
+                  onInput: (value) => Message.UpdatedOtp({ value }),
+                },
+                h,
               ),
             ],
             h,
@@ -82,9 +87,15 @@ export const inputOtpView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
           field<AppMessage>(
             {},
             [
-              fieldLabel<AppMessage>({ for: 'with-separator' }, ['With Separator'], h),
+              fieldLabel<AppMessage>({ for: 'otp-separator' }, ['With Separator'], h),
               inputOtp<AppMessage>(
-                { length: 6, value: model.otp, onInput: (value) => Message.UpdatedOtp({ value }) },
+                {
+                  length: 6,
+                  value: model.otpSeparated,
+                  id: 'otp-separator',
+                  onInput: (value) => Message.UpdatedSeparatedOtp({ value }),
+                  children: separatedGroups(h, model.otpSeparated),
+                },
                 h,
               ),
             ],
@@ -99,11 +110,16 @@ export const inputOtpView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
           field<AppMessage>(
             {},
             [
-              fieldLabel<AppMessage>({ for: 'four-digits' }, ['4 Digits'], h),
+              fieldLabel<AppMessage>({ for: 'otp-four' }, ['4 Digits'], h),
               fieldDescription<AppMessage>({}, ['Common pattern for PIN codes.'], h),
-              h.div(
-                [h.Class(inputOtpClass), h.DataAttribute('slot', 'input-otp')],
-                [otpSlots(h, 4, '1234')],
+              inputOtp<AppMessage>(
+                {
+                  length: 4,
+                  value: model.otpFour,
+                  id: 'otp-four',
+                  onInput: (value) => Message.UpdatedFourOtp({ value }),
+                },
+                h,
               ),
             ],
             h,
@@ -117,15 +133,10 @@ export const inputOtpView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
           field<AppMessage>(
             {},
             [
-              fieldLabel<AppMessage>({ for: 'disabled' }, ['Disabled'], h),
-              h.div(
-                [h.Class(`${inputOtpClass} opacity-50`), h.DataAttribute('slot', 'input-otp')],
-                [
-                  h.div(
-                    [h.Class('flex items-center gap-2')],
-                    [otpSlots(h, 3, '123'), inputOtpSeparator({}, h), otpSlots(h, 3, '456')],
-                  ),
-                ],
+              fieldLabel<AppMessage>({ for: 'otp-disabled' }, ['Disabled'], h),
+              inputOtp<AppMessage>(
+                { length: 6, value: '123456', id: 'otp-disabled', isDisabled: true },
+                h,
               ),
             ],
             h,
@@ -139,22 +150,18 @@ export const inputOtpView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
           field<AppMessage>(
             {},
             [
-              fieldLabel<AppMessage>({ for: 'invalid' }, ['Invalid State'], h),
+              fieldLabel<AppMessage>({ for: 'otp-invalid' }, ['Invalid State'], h),
               fieldDescription<AppMessage>({}, ['Example showing the invalid error state.'], h),
-              h.div(
-                [h.Class(inputOtpClass), h.DataAttribute('slot', 'input-otp')],
-                [
-                  h.div(
-                    [h.Class('flex items-center gap-2')],
-                    [
-                      otpSlots(h, 2, '00', true),
-                      inputOtpSeparator({}, h),
-                      otpSlots(h, 2, '00', true),
-                      inputOtpSeparator({}, h),
-                      otpSlots(h, 2, '00', true),
-                    ],
-                  ),
-                ],
+              inputOtp<AppMessage>(
+                {
+                  length: 6,
+                  value: model.otpInvalid,
+                  id: 'otp-invalid',
+                  isInvalid: true,
+                  onInput: (value) => Message.UpdatedInvalidOtp({ value }),
+                  children: separatedGroups(h, model.otpInvalid, true),
+                },
+                h,
               ),
               fieldError<AppMessage>(
                 { errors: [{ message: 'Invalid code. Please try again.' }] },
@@ -170,8 +177,23 @@ export const inputOtpView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
         [
           h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], ['Controlled']),
           inputOtp<AppMessage>(
-            { length: 6, value: model.otp, onInput: (value) => Message.UpdatedOtp({ value }) },
+            {
+              length: 6,
+              value: model.otpControlled,
+              id: 'otp-controlled',
+              onInput: (value) => Message.UpdatedControlledOtp({ value }),
+            },
             h,
+          ),
+          h.div(
+            [h.Class('text-center text-sm')],
+            [
+              model.otpControlled === ''
+                ? 'Enter your one-time password.'
+                : model.otpControlled.length >= 6
+                  ? `You entered: ${model.otpControlled}`
+                  : `${6 - model.otpControlled.length} digits remaining.`,
+            ],
           ),
         ],
       ),
@@ -210,6 +232,7 @@ export const inputOtpView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
                     {
                       length: 6,
                       value: model.otp,
+                      id: 'otp-verification',
                       onInput: (value) => Message.UpdatedOtp({ value }),
                     },
                     h,
@@ -239,19 +262,49 @@ export const inputOtpView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
     ],
   )
 
-const fields = { otp: S.String }
+const fields = {
+  otp: S.String,
+  otpSeparated: S.String,
+  otpFour: S.String,
+  otpControlled: S.String,
+  otpInvalid: S.String,
+}
 
 const stateSchema = S.Struct(fields)
 type State = typeof stateSchema.Type
 
 export const slice = defineSlice({
   fields,
-  init: { otp: '123456' },
-  messages: [Message.UpdatedOtp],
+  init: { otp: '123456', otpSeparated: '', otpFour: '', otpControlled: '', otpInvalid: '000000' },
+  messages: [
+    Message.UpdatedOtp,
+    Message.UpdatedSeparatedOtp,
+    Message.UpdatedFourOtp,
+    Message.UpdatedControlledOtp,
+    Message.UpdatedInvalidOtp,
+  ],
   handlers: (model: State) => ({
     UpdatedOtp: ({ value }: typeof Message.UpdatedOtp.Type): UpdateReturn => ({
       model: evo(model, { otp: () => value }),
     }),
+    UpdatedSeparatedOtp: ({ value }: typeof Message.UpdatedSeparatedOtp.Type): UpdateReturn => ({
+      model: evo(model, { otpSeparated: () => value }),
+    }),
+    UpdatedFourOtp: ({ value }: typeof Message.UpdatedFourOtp.Type): UpdateReturn => ({
+      model: evo(model, { otpFour: () => value }),
+    }),
+    UpdatedControlledOtp: ({ value }: typeof Message.UpdatedControlledOtp.Type): UpdateReturn => ({
+      model: evo(model, { otpControlled: () => value }),
+    }),
+    UpdatedInvalidOtp: ({ value }: typeof Message.UpdatedInvalidOtp.Type): UpdateReturn => ({
+      model: evo(model, { otpInvalid: () => value }),
+    }),
   }),
-  samples: [Message.UpdatedOtp({ value: '1234' })],
+  samples: [
+    Message.UpdatedOtp({ value: '1234' }),
+    Message.UpdatedSeparatedOtp({ value: '12' }),
+    Message.UpdatedFourOtp({ value: '34' }),
+    Message.UpdatedControlledOtp({ value: '56' }),
+    Message.UpdatedInvalidOtp({ value: '00' }),
+  ],
 })

--- a/packages/web/src/input-otp.test.ts
+++ b/packages/web/src/input-otp.test.ts
@@ -1,0 +1,208 @@
+// Regression guard: the OTP update channel must never starve.
+//
+// Upstream `input-otp` fires `onChange` on every change (typing, deleting,
+// pasting) and `onComplete` once per transition to a full code; the two are
+// independent. Foldcn maps both onto foldkit's single-message-per-event
+// handlers, so the contract is: `onInput` fires on every change including
+// the completing one, and `onComplete` alone doubles as the update channel
+// when `onInput` is absent. Before this guard, a full code dispatched only
+// `onComplete`, so a consumer wiring `onInput` to store the value and
+// `onComplete` to react (submit, verify) silently lost the final digit and
+// the field snapped back to one-short on re-render.
+import { describe, it } from 'vitest'
+import { Scene } from 'foldkit/test'
+import type { Html, HtmlBuilder } from 'foldkit/html'
+
+import * as InputOtp from '../../registry/registry/default/ui/input-otp'
+
+type Message = Readonly<{ tag: 'input' | 'complete'; value: string }>
+type Model = Readonly<{ otp: string; submitted: string | null }>
+
+const message =
+  (tag: Message['tag']) =>
+  (value: string): Message => ({ tag, value })
+
+// Dual wiring, the way a controlled consumer pairs the two callbacks: the
+// update channel stores the value, the completion channel reacts to it.
+const dualUpdate = (model: Model, msg: Message) =>
+  msg.tag === 'input'
+    ? { model: { ...model, otp: msg.value } }
+    : { model: { ...model, submitted: msg.value } }
+
+// Sole-channel wiring: with no update channel of its own, the owner stores
+// from whichever callback fires.
+const soleUpdate = (model: Model, msg: Message) => ({
+  model: { ...model, otp: msg.value },
+})
+
+const init: Model = { otp: '', submitted: null }
+
+const otpInput = Scene.selector('input[data-slot="input-otp-input"]')
+
+const viewBoth = (model: Model, h: HtmlBuilder<Message>): Html =>
+  h.div(
+    [],
+    [
+      InputOtp.inputOtp(
+        {
+          length: 6,
+          value: model.otp,
+          onInput: message('input'),
+          onComplete: message('complete'),
+        },
+        h,
+      ),
+      h.div([], [model.submitted === null ? 'not-submitted' : `submitted:${model.submitted}`]),
+    ],
+  )
+
+const viewInputOnly = (model: Model, h: HtmlBuilder<Message>): Html =>
+  InputOtp.inputOtp({ length: 6, value: model.otp, onInput: message('input') }, h)
+
+const viewCompleteOnly = (model: Model, h: HtmlBuilder<Message>): Html =>
+  InputOtp.inputOtp({ length: 6, value: model.otp, onComplete: message('complete') }, h)
+
+describe('input-otp update channel', () => {
+  it('stores the completing digit when onInput and onComplete are both wired', () => {
+    Scene.scene(
+      { update: dualUpdate, view: viewBoth },
+      Scene.given({ ...init, otp: '12345' }),
+      Scene.type(otpInput, '123456'),
+      Scene.expect(Scene.text('6')).toExist(),
+      Scene.expect(Scene.text('not-submitted')).toExist(),
+    )
+  })
+  it('stores partial edits through onInput alone', () => {
+    Scene.scene(
+      { update: soleUpdate, view: viewInputOnly },
+      Scene.given(init),
+      Scene.type(otpInput, '12a34'),
+      Scene.expect(Scene.text('4')).toExist(),
+    )
+  })
+  it('stores edits through onComplete alone when onInput is absent', () => {
+    Scene.scene(
+      { update: soleUpdate, view: viewCompleteOnly },
+      Scene.given(init),
+      Scene.type(otpInput, '789'),
+      Scene.expect(Scene.text('9')).toExist(),
+    )
+  })
+})
+
+describe('input-otp pure core', () => {
+  it('strips non-digits and caps at length', () => {
+    const cases: ReadonlyArray<readonly [string, number, string]> = [
+      ['12a34', 6, '1234'],
+      ['1234567', 6, '123456'],
+      [' 1-2 3 ', 6, '123'],
+      ['', 4, ''],
+    ]
+    for (const [raw, length, expected] of cases) {
+      if (InputOtp.normalizeOtpValue(raw, length) !== expected) {
+        throw new Error(`normalizeOtpValue(${JSON.stringify(raw)}, ${length}) mismatch`)
+      }
+    }
+  })
+  it('reports completion only at full length', () => {
+    if (!InputOtp.isCompleteOtpValue('123456', 6)) throw new Error('full code not complete')
+    if (InputOtp.isCompleteOtpValue('12345', 6)) throw new Error('partial code complete')
+  })
+  it('marks exactly the next-to-fill slot active', () => {
+    const states = InputOtp.otpSlotStates('12', 4)
+    const active = states.filter((slot) => slot.isActive)
+    const first = active[0]
+    if (active.length !== 1 || first === undefined || first.index !== 2) {
+      throw new Error(`active slot mismatch: ${JSON.stringify(active)}`)
+    }
+    if (states[0]?.char !== '1' || states[2]?.char !== null) {
+      throw new Error(`slot chars mismatch: ${JSON.stringify(states)}`)
+    }
+  })
+})
+
+describe('input-otp composition parts', () => {
+  it('renders caller-composed groups, slots and separators around one input', () => {
+    const composed = (_model: Model, h: HtmlBuilder<Message>): Html =>
+      InputOtp.inputOtp(
+        {
+          length: 4,
+          value: '12',
+          onInput: message('input'),
+          children: [
+            InputOtp.inputOtpGroup(
+              { className: 'first' },
+              [
+                InputOtp.inputOtpSlot({ index: 0, value: '12', length: 4 }, h),
+                InputOtp.inputOtpSlot({ index: 1, value: '12', length: 4 }, h),
+              ],
+              h,
+            ),
+            InputOtp.inputOtpSeparator({}, h),
+            InputOtp.inputOtpGroup(
+              {},
+              [
+                InputOtp.inputOtpSlot({ index: 2, value: '12', length: 4 }, h),
+                InputOtp.inputOtpSlot({ index: 3, value: '12', length: 4 }, h),
+              ],
+              h,
+            ),
+          ],
+        },
+        h,
+      )
+    Scene.scene(
+      { update: soleUpdate, view: composed },
+      Scene.given(init),
+      Scene.expect(otpInput).toExist(),
+      Scene.expect(Scene.selector('[data-slot="input-otp-separator"]')).toExist(),
+      Scene.expect(Scene.text('1')).toExist(),
+      Scene.expect(Scene.text('2')).toExist(),
+    )
+  })
+  it('marks slots invalid when invalid', () => {
+    const invalid = (_model: Model, h: HtmlBuilder<Message>): Html =>
+      InputOtp.inputOtp({ length: 2, value: '00', isInvalid: true }, h)
+    Scene.scene(
+      { update: soleUpdate, view: invalid },
+      Scene.given(init),
+      Scene.expect(Scene.selector('[data-slot="input-otp-slot"][aria-invalid="true"]')).toExist(),
+    )
+  })
+  it('threads invalid through caller-composed groups', () => {
+    const composedInvalid = (_model: Model, h: HtmlBuilder<Message>): Html =>
+      InputOtp.inputOtp(
+        {
+          length: 4,
+          value: '00',
+          isInvalid: true,
+          children: [
+            InputOtp.inputOtpGroup(
+              {},
+              [
+                InputOtp.inputOtpSlot({ index: 0, value: '00', length: 4, isInvalid: true }, h),
+                InputOtp.inputOtpSlot({ index: 1, value: '00', length: 4, isInvalid: true }, h),
+              ],
+              h,
+            ),
+            InputOtp.inputOtpSeparator({}, h),
+            InputOtp.inputOtpGroup(
+              {},
+              [
+                InputOtp.inputOtpSlot({ index: 2, value: '00', length: 4, isInvalid: true }, h),
+                InputOtp.inputOtpSlot({ index: 3, value: '00', length: 4, isInvalid: true }, h),
+              ],
+              h,
+            ),
+          ],
+        },
+        h,
+      )
+    Scene.scene(
+      { update: soleUpdate, view: composedInvalid },
+      Scene.given(init),
+      Scene.expect(Scene.selector('[data-slot="input-otp-separator"]')).toExist(),
+      Scene.expect(Scene.selector('[data-slot="input-otp-slot"][aria-invalid="true"]')).toExist(),
+    )
+  })
+})


### PR DESCRIPTION
The completing keystroke never reached the update channel when both callbacks were wired. Typing the sixth digit dispatched only `onComplete`, so a consumer storing state in `onInput` silently lost the final digit and the field snapped back to one short on re-render.

## Root cause

The `OnInput` handler in `packages/registry/registry/default/ui/input-otp.ts` gave `onComplete` priority at full length. Upstream `input-otp` fires `onChange` on every change and `onComplete` once per transition to full, and the two are independent. Foldkit maps one DOM event to one message, so both can never fire for the same keystroke, and the old code kept the wrong one.

Reproduced in the live demo before fixing: with the field full at `123456`, selecting all and typing `987` left the value at `123456` with no input event reaching the model. An instrumented listener confirmed the dispatch path itself was healthy, which isolated the bug to handler routing.

## The contract now

`onInput` fires on every change, including the completing one. It mirrors upstream `onChange`. With no `onInput`, `onComplete` doubles as the update channel on every change, and the owner checks `isCompleteOtpValue(next, length)` before treating the value as complete. Controlled owners derive completion from their stored value. The two callbacks never fire for the same keystroke, and the config docs state that.

## What changed

- `packages/registry/registry/default/ui/input-otp.ts`: handler fix above, plus a dependency-free headless core (`normalizeOtpValue`, `isCompleteOtpValue`, `otpSlotStates`) with no foldkit import, so it can move verbatim into a future `@foldkit/ui` OTP primitive. New `inputOtpGroup` and `inputOtpSlot` parts allow multi-group layouts with separators, matching upstream composition without context. New `isInvalid` threads `aria-invalid` onto slots so the group's invalid ring lights, and new `id` associates labels with the input. Native `maxlength` is removed: it truncated pasted codes before digit stripping, so pasting `12 34-56` lost digits. Normalization caps length instead. Inactive slots now carry `data-active="false"`, exactly like upstream.
- `packages/web/src/input-otp.test.ts`: 9 Scene and pure-core tests. The dual-wiring test fails on the old dispatch and pins both halves of the contract, stored value plus no double completion. Composition and invalid-threading paths are covered.
- `packages/web/src/demo/views/input-otp.ts`: every example renders the live component. The separator example composes 2/2/2 groups through the new children API, Invalid uses `isInvalid`, Disabled is handler-free, Controlled owns its own field with a completion readout, and labels point at real input ids.
- `packages/web/src/catalog/gaps.ts` and `docs/shadcn-base-parity-audit.md`: record the remaining numeric-only divergence. The audit moves input-otp from MAJOR to MINOR, 19 minor and 29 major over 52 unchanged pairs.

Class strings stay character-identical to upstream base, and no resolved Tailwind leaks into authored sources.

## Verification

- `vitest run src/input-otp.test.ts`: 9 passed. The suite went red first, 6 failed, before the fix.
- Full web suite: 38 passed, 1 failed. The failure is the `command-behavior` demo-parent test timing out, and it fails identically on the clean tree.
- `tsc --noEmit`, `vp lint`, `@foldcn/registry build`, and repo-wide `turbo run build` plus `turbo run typecheck` are all green.
- Browser on `/docs/input-otp`: typed digits flow into 2/2/2 slots across separators, paste of `12 34-56` normalizes to `123456`, backspace syncs the model, all six invalid slots carry `aria-invalid`, and label click focuses each input.

## Infra note

Pushing needed a serial `turbo run build` then `turbo run typecheck` warmup first. The pre-push hook runs both in parallel, and parallel `resolve-styles.mjs` invocations race on `packages/registry/styles/`, ENOTEMPTY on rm and ENOENT on read. That race predates this change. Worth a lock or a single resolve step in the hook.
