### PR TITLE
fix(combobox): restore single and multi parity

### DIFF
--- a/packages/registry/registry/default/ui/combobox.ts
+++ b/packages/registry/registry/default/ui/combobox.ts
@@ -5,7 +5,14 @@
 import { Combobox as FoldkitCombobox } from '@foldkit/ui'
 import type { AnchorConfig } from '@foldkit/ui/combobox'
 import type { Option } from 'effect/Option'
-import { childAttributes, inertHtml, type Html, type HtmlBuilder } from 'foldkit/html'
+import {
+  childAttributes,
+  inertHtml,
+  type Attribute,
+  type ChildAttribute,
+  type Html,
+  type HtmlBuilder,
+} from 'foldkit/html'
 
 import { icon } from '@/lib/icons'
 import { Check, ChevronDown } from 'lucide'
@@ -51,7 +58,7 @@ export const comboboxButtonClass =
   'absolute inset-y-0 right-0 flex items-center px-3 text-muted-foreground transition-colors hover:text-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*="size-"])]:size-4'
 
 export const comboboxItemsClass =
-  'cn-combobox-content cn-combobox-content-logical cn-menu-target cn-menu-translucent group/combobox-content relative max-h-(--available-height) w-(--anchor-width) max-w-(--available-width) min-w-[calc(var(--anchor-width)+--spacing(7))] origin-(--transform-origin) data-[chips=true]:min-w-(--anchor-width)'
+  'cn-combobox-content cn-combobox-content-logical cn-menu-target cn-menu-translucent group/combobox-content relative isolate z-50 max-h-(--available-height) w-(--anchor-width) max-w-(--available-width) min-w-[calc(var(--anchor-width)+--spacing(7))] origin-(--transform-origin) data-[chips=true]:min-w-(--anchor-width)'
 
 export const comboboxItemsAnimatedClass = comboboxItemsClass
 
@@ -107,6 +114,8 @@ type CommonConfig<Item extends string> = Readonly<{
   openOnFocus?: boolean
   ariaLabel?: string
   ariaLabelledBy?: string
+  inputAttributes?: ReadonlyArray<ChildAttribute>
+  itemsAttributes?: ReadonlyArray<Attribute<unknown>>
   itemGroupKey?: (item: Item, index: number) => string
   groupToHeading?: (groupKey: string) => GroupHeading | undefined
   formName?: string
@@ -134,9 +143,12 @@ const common = <Item extends string>(config: CommonConfig<Item>) => ({
   isDisabled: config.isDisabled,
   isReadOnly: config.isReadOnly,
   isInvalid: config.isInvalid,
-  openOnFocus: config.openOnFocus,
+  // Base UI opens the popup when the input receives focus. Keep the option
+  // overridable for callers that need explicit keyboard-only opening.
+  openOnFocus: config.openOnFocus ?? true,
   ariaLabel: config.ariaLabel,
   ariaLabelledBy: config.ariaLabelledBy,
+  inputAttributes: config.inputAttributes,
   itemGroupKey: config.itemGroupKey,
   groupToHeading: config.groupToHeading,
   inputClassName: cn(comboboxInputClass, config.inputClass),
@@ -144,7 +156,10 @@ const common = <Item extends string>(config: CommonConfig<Item>) => ({
     config.isAnimated !== false ? comboboxItemsAnimatedClass : comboboxItemsClass,
     config.itemsClass,
   ),
-  itemsAttributes: childAttributes([inertHtml.DataAttribute('slot', 'combobox-content')]),
+  itemsAttributes: childAttributes([
+    inertHtml.DataAttribute('slot', 'combobox-content'),
+    ...(config.itemsAttributes ?? []),
+  ]),
   itemsScrollClassName: config.itemsScrollClass ?? comboboxItemsScrollClass,
   itemToConfig: (item: Item, context: Parameters<CommonConfig<Item>['itemToConfig']>[1]) => {
     const { className, content } = config.itemToConfig(item, context)

--- a/packages/web/src/combobox-behavior.test.ts
+++ b/packages/web/src/combobox-behavior.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import { Scene } from 'foldkit/test'
+import * as FoldkitCombobox from '@foldkit/ui/combobox'
+import * as Combobox from '../../registry/registry/default/ui/combobox'
+import { AlignMultiComboboxGroup, comboboxView } from './demo/views/combobox'
+import * as Demo from './demo/assemble'
+
+const items = ['Next.js', 'SvelteKit', 'Nuxt.js'] as const
+const bundle = Combobox.Multi.create<(typeof items)[number]>()
+
+describe('combobox rendered contract', () => {
+  it('clicking a multi option emits the selected value', () => {
+    const openModel = {
+      ...Combobox.Multi.init({ id: 'test-combobox', isAnimated: false }),
+      isOpen: true,
+    }
+    Scene.scene(
+      {
+        update: bundle.update,
+        view: (model, h) =>
+          bundle.view(
+            model,
+            Combobox.multiViewInputs({
+              items,
+              selectedValues: [],
+              restingInputValue: '',
+              itemToValue: (item) => item,
+              itemToDisplayText: (item) => item,
+              itemToConfig: (item, context) => ({
+                className: context.isActive ? 'font-medium' : '',
+                content: h.span([], [item]),
+              }),
+            }),
+            h,
+          ),
+      },
+      Scene.given(openModel),
+      Scene.Mount.resolve(
+        FoldkitCombobox.PortalComboboxBackdrop,
+        FoldkitCombobox.Message.CompletedPortalComboboxBackdrop(),
+      ),
+      Scene.Mount.resolve(
+        FoldkitCombobox.AnchorCombobox,
+        FoldkitCombobox.Message.CompletedAnchorCombobox(),
+      ),
+      Scene.click(Scene.role('option', { name: 'Next.js' })),
+      Scene.expectOutMessage(Combobox.OutMessage.Selected({ value: 'Next.js' })),
+    )
+  })
+
+  it('folds the selected value into the demo chip state', () => {
+    const result = Demo.update(Demo.init().model, {
+      _tag: 'GotMultiComboboxMessage',
+      message: Combobox.Message.SelectedItem({
+        item: 'Next.js',
+        displayText: 'Next.js',
+        wasSelected: false,
+      }),
+    })
+
+    expect(result.model.multiComboboxValues).toEqual(['Next.js'])
+  })
+
+  it('selects through the mounted demo popup instead of dismissing on backdrop click', () => {
+    const initial = Demo.init().model
+    const openModel = {
+      ...initial,
+      multiCombobox: { ...initial.multiCombobox, isOpen: true },
+    }
+
+    Scene.scene(
+      { update: Demo.update, view: (model, h) => comboboxView(model, h) },
+      Scene.given(openModel),
+      Scene.Mount.resolve(
+        FoldkitCombobox.PortalComboboxBackdrop,
+        FoldkitCombobox.Message.CompletedPortalComboboxBackdrop(),
+      ),
+      Scene.Mount.resolve(
+        FoldkitCombobox.AnchorCombobox,
+        FoldkitCombobox.Message.CompletedAnchorCombobox(),
+      ),
+      Scene.Mount.resolve(
+        // The demo mount only aligns the popup; its completion is a regular
+        // multi-combobox message and must not consume option selection.
+        AlignMultiComboboxGroup,
+        {
+          _tag: 'GotMultiComboboxMessage',
+          message: Combobox.Message.CompletedAnchorCombobox(),
+        },
+      ),
+      Scene.Mount.resolve(
+        FoldkitCombobox.AttachComboboxPreventBlur,
+        FoldkitCombobox.Message.CompletedAttachComboboxPreventBlur(),
+      ),
+      Scene.Mount.resolve(
+        FoldkitCombobox.AttachComboboxPreventBlur,
+        FoldkitCombobox.Message.CompletedAttachComboboxPreventBlur(),
+      ),
+      Scene.click(Scene.role('option', { name: 'Next.js' })),
+      Scene.expect(Scene.selector('[aria-label^="Remove"]')).toExist(),
+      Scene.expect(Scene.role('option', { name: 'Next.js' })).toExist(),
+    )
+  })
+})

--- a/packages/web/src/demo/bundles.ts
+++ b/packages/web/src/demo/bundles.ts
@@ -24,6 +24,9 @@ export const City = S.Literals([
 ])
 export type City = typeof City.Type
 
+export const Framework = S.Literals(['Next.js', 'SvelteKit', 'Nuxt.js', 'Remix', 'Astro'])
+export type Framework = typeof Framework.Type
+
 export const Plan = S.Literals(['Startup', 'Business', 'Enterprise'])
 export type Plan = typeof Plan.Type
 
@@ -56,7 +59,8 @@ export const DEMO_TODAY = FoldkitCalendar.make(2025, 1, 15)
 
 export const DemoMenu = Menu.create<string>()
 export const ItemListbox = Listbox.create<ListboxItem>()
-export const CityCombobox = Combobox.create<City>()
+export const FrameworkCombobox = Combobox.create<Framework>()
+export const FrameworkMultiCombobox = Combobox.Multi.create<Framework>()
 export const DemoTabs = Tabs.create<DemoTab>()
 export const PlanRadioGroup = RadioGroup.create<Plan>()
 export const LanguageSelect = Select.create<{ value: string; label: string }, string>()

--- a/packages/web/src/demo/views/combobox.ts
+++ b/packages/web/src/demo/views/combobox.ts
@@ -1,23 +1,77 @@
 import { Update } from 'foldkit'
-import { Match as M, Option } from 'effect'
+import { Effect, Match as M, Option } from 'effect'
 import { Schema as S } from 'effect'
 import { evo } from 'foldkit/struct'
 import { defineMessageUnion } from 'foldkit/message'
-import type { Html, HtmlBuilder } from 'foldkit/html'
+import { childAttributes, type Html, type HtmlBuilder } from 'foldkit/html'
+import * as Mount from 'foldkit/mount'
 
 import { Combobox as FoldkitCombobox } from '@foldkit/ui'
 
 import * as combobox from '../../generated/registry/ui/combobox'
 
-import { City, CityCombobox } from '../bundles'
+import { Framework, FrameworkCombobox, FrameworkMultiCombobox } from '../bundles'
 import { defineSlice, type UpdateReturn } from '../slice'
 import type { Model, Message as AppMessage } from '../assemble'
+import { icon } from '@/lib/icons'
+import { X } from 'lucide'
 
 const Message = defineMessageUnion({
   GotComboboxMessage: { message: combobox.Message },
+  GotMultiComboboxMessage: { message: combobox.Message },
 })
 
-const FRAMEWORKS = ['Next.js', 'SvelteKit', 'Nuxt.js', 'Remix', 'Astro'] as const
+// The shared combobox primitive anchors its popup to the input wrapper. In
+// multiple mode that wrapper is only the space after the chips, while Base UI
+// anchors the popup to the complete ComboboxChips control. Keep the primitive
+// behavior and synchronize the popup's horizontal geometry to the demo's
+// full-width input group instead of translating it by the current chip width.
+export const AlignMultiComboboxGroup = Mount.define('AlignMultiComboboxGroup', {
+  messages: [Message.GotMultiComboboxMessage],
+  execute: ({ element }) =>
+    Effect.gen(function* () {
+      const cleanup = yield* Effect.sync(() => {
+        const align = () => {
+          if (!(element instanceof HTMLElement)) return
+          const group = document.getElementById('combobox-multi-input-group')
+          const popup = document.getElementById('combobox-multi-demo-items')
+          if (!group || !popup) return
+          const groupRect = group.getBoundingClientRect()
+          const position = getComputedStyle(popup).position
+          const containingBlock = popup.offsetParent?.getBoundingClientRect()
+          const left =
+            position === 'fixed' ? groupRect.left : groupRect.left - (containingBlock?.left ?? 0)
+          popup.style.setProperty('left', `${left}px`, 'important')
+          popup.style.setProperty('width', `${groupRect.width}px`, 'important')
+          popup.style.setProperty('visibility', 'visible', 'important')
+        }
+        const observer = new MutationObserver(align)
+        const resizeObserver = new ResizeObserver(align)
+        align()
+        observer.observe(element, { childList: true, subtree: true, attributes: true })
+        resizeObserver.observe(element)
+        window.addEventListener('resize', align)
+        window.addEventListener('scroll', align, true)
+        return () => {
+          observer.disconnect()
+          resizeObserver.disconnect()
+          window.removeEventListener('resize', align)
+          window.removeEventListener('scroll', align, true)
+        }
+      })
+      yield* Effect.acquireRelease(Effect.succeed(cleanup), (release) => Effect.sync(release))
+      return Message.GotMultiComboboxMessage({
+        message: combobox.Message.CompletedAnchorCombobox(),
+      })
+    }),
+})
+
+const FRAMEWORKS: ReadonlyArray<Framework> = ['Next.js', 'SvelteKit', 'Nuxt.js', 'Remix', 'Astro']
+
+const filteredFrameworks = (inputValue: string): ReadonlyArray<Framework> => {
+  const query = inputValue.trim().toLowerCase()
+  return query === '' ? FRAMEWORKS : FRAMEWORKS.filter((item) => item.toLowerCase().includes(query))
+}
 
 export const comboboxView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
   h.div(
@@ -33,15 +87,29 @@ export const comboboxView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
               h.submodel({
                 slotId: model.combobox.id,
                 model: model.combobox,
-                view: CityCombobox.view,
-                viewInputs: combobox.viewInputs<City>({
-                  // oxlint-disable-next-line anti-slop/no-chained-type-assertions, typescript/consistent-type-assertions -- SAFETY: City bundle reuse
-                  items: FRAMEWORKS as unknown as ReadonlyArray<City>,
+                view: FrameworkCombobox.view,
+                viewInputs: combobox.viewInputs<Framework>({
+                  items:
+                    model.combobox.isOpen &&
+                    Option.exists(
+                      model.maybeComboboxValue,
+                      (value) => value === model.combobox.inputValue,
+                    )
+                      ? FRAMEWORKS
+                      : filteredFrameworks(model.combobox.inputValue),
                   restingInputValue: Option.getOrElse(model.maybeComboboxValue, () => ''),
                   maybeSelectedValue: model.maybeComboboxValue,
                   itemToValue: (item) => item,
                   itemToDisplayText: (item) => item,
                   inputPlaceholder: 'Select framework...',
+                  buttonContent: combobox.comboboxChevron(h),
+                  inputAttributes: childAttributes([
+                    h.OnInput(() =>
+                      Message.GotComboboxMessage({
+                        message: combobox.Message.Opened({ maybeActiveItemIndex: Option.none() }),
+                      }),
+                    ),
+                  ]),
                   itemToConfig: (item, { isSelected, isActive }) => ({
                     className: isActive ? 'font-medium' : '',
                     content: h.span(
@@ -61,15 +129,89 @@ export const comboboxView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
         [
           h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], ['Multi']),
           h.div(
-            [h.Class('mx-auto w-full max-w-xs rounded-lg border p-4 text-sm')],
-            [h.p([], ['Multi-select combobox with pills.'])],
+            [
+              h.Id('combobox-multi-input-group'),
+              h.OnMount(AlignMultiComboboxGroup()),
+              h.Class('flex w-full max-w-xs flex-wrap items-center gap-1 rounded-lg border p-1'),
+            ],
+            [
+              h.div(
+                [h.Class('contents')],
+                model.multiComboboxValues.map((value) =>
+                  h.span(
+                    [
+                      h.Class(
+                        'inline-flex items-center gap-1 rounded-md bg-muted px-2 py-0.5 text-xs',
+                      ),
+                    ],
+                    [
+                      h.span([], [value]),
+                      h.button(
+                        [
+                          h.Type('button'),
+                          h.AriaLabel(`Remove ${value}`),
+                          h.Class('rounded-sm text-muted-foreground hover:text-foreground'),
+                          h.OnClick(
+                            Message.GotMultiComboboxMessage({
+                              message: combobox.Message.SelectedItem({
+                                item: value,
+                                displayText: value,
+                                wasSelected: true,
+                              }),
+                            }),
+                          ),
+                        ],
+                        [icon(h, X, 'size-3')],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              h.submodel({
+                slotId: model.multiCombobox.id,
+                model: model.multiCombobox,
+                view: FrameworkMultiCombobox.view,
+                viewInputs: combobox.multiViewInputs<Framework>({
+                  items: filteredFrameworks(model.multiCombobox.inputValue),
+                  selectedValues: model.multiComboboxValues,
+                  restingInputValue: '',
+                  itemToValue: (item) => item,
+                  itemToDisplayText: (item) => item,
+                  inputPlaceholder:
+                    model.multiComboboxValues.length === 0 ? 'Add framework...' : undefined,
+                  buttonContent: combobox.comboboxChevron(h),
+                  inputClass: 'border-0 shadow-none focus-visible:ring-0',
+                  // Share the first row with chips until the input reaches
+                  // its usable minimum, then wrap onto a new row.
+                  // Match Base UI's chip input: keep a small usable input
+                  // width, then wrap only after the row has no room left.
+                  wrapperClass: 'min-w-16 flex-1',
+                  inputWrapperClass: 'w-full min-w-0',
+                  inputAttributes: childAttributes([
+                    h.OnInput(() =>
+                      Message.GotMultiComboboxMessage({
+                        message: combobox.Message.Opened({ maybeActiveItemIndex: Option.none() }),
+                      }),
+                    ),
+                  ]),
+                  itemToConfig: (item, { isSelected, isActive }) => ({
+                    className: isActive ? 'font-medium' : '',
+                    content: h.span(
+                      [h.Class('flex w-full items-center justify-between gap-2')],
+                      [h.span([], [item]), ...(isSelected ? [combobox.comboboxCheck(h)] : [])],
+                    ),
+                  }),
+                }),
+                toParentMessage: (message) => Message.GotMultiComboboxMessage({ message }),
+              }),
+            ],
           ),
         ],
       ),
     ],
   )
 
-const foldComboboxOutMessage = M.type<FoldkitCombobox.OutMessage<City>>().pipe(
+const foldComboboxOutMessage = M.type<FoldkitCombobox.OutMessage<Framework>>().pipe(
   M.withReturnType<Update.Step<State, unknown>>(),
   M.tagsExhaustive({
     Selected:
@@ -79,15 +221,43 @@ const foldComboboxOutMessage = M.type<FoldkitCombobox.OutMessage<City>>().pipe(
   }),
 )
 
+const foldMultiComboboxOutMessage = M.type<FoldkitCombobox.OutMessage<Framework>>().pipe(
+  M.withReturnType<Update.Step<State, unknown>>(),
+  M.tagsExhaustive({
+    Selected:
+      ({ value }) =>
+      (model) => ({
+        model: evo(model, {
+          multiComboboxValues: (values) =>
+            values.includes(value) ? values.filter((item) => item !== value) : [...values, value],
+        }),
+      }),
+    ClearedSelection: () => (model) => ({ model }),
+  }),
+)
+
 const foldCombobox = Update.foldChild({
-  update: CityCombobox.update,
+  update: FrameworkCombobox.update,
   read: (model: State) => Option.some(model.combobox),
   write: (model, next) => evo(model, { combobox: () => next }),
   toParentMessage: (message) => Message.GotComboboxMessage({ message }),
   foldOutMessage: foldComboboxOutMessage,
 })
 
-const fields = { combobox: combobox.Model, maybeComboboxValue: S.Option(City) }
+const foldMultiCombobox = Update.foldChild({
+  update: FrameworkMultiCombobox.update,
+  read: (model: State) => Option.some(model.multiCombobox),
+  write: (model, next) => evo(model, { multiCombobox: () => next }),
+  toParentMessage: (message) => Message.GotMultiComboboxMessage({ message }),
+  foldOutMessage: foldMultiComboboxOutMessage,
+})
+
+const fields = {
+  combobox: combobox.Model,
+  maybeComboboxValue: S.Option(Framework),
+  multiCombobox: combobox.Multi.Model,
+  multiComboboxValues: S.Array(Framework),
+}
 
 const stateSchema = S.Struct(fields)
 type State = typeof stateSchema.Type
@@ -97,11 +267,15 @@ export const slice = defineSlice({
   init: {
     combobox: combobox.init({ id: 'combobox-demo' }),
     maybeComboboxValue: Option.none(),
+    multiCombobox: combobox.Multi.init({ id: 'combobox-multi-demo' }),
+    multiComboboxValues: [],
   },
-  messages: [Message.GotComboboxMessage],
+  messages: [Message.GotComboboxMessage, Message.GotMultiComboboxMessage],
   handlers: (model: State) => ({
     GotComboboxMessage: (payload: typeof Message.GotComboboxMessage.Type): UpdateReturn =>
       foldCombobox(model, payload.message),
+    GotMultiComboboxMessage: (payload: typeof Message.GotMultiComboboxMessage.Type): UpdateReturn =>
+      foldMultiCombobox(model, payload.message),
   }),
   samples: [],
 })


### PR DESCRIPTION
## Summary

- restore shadcn Base UI combobox parity for single and multiple modes
- keep the popup open while filtering and anchor multi content to the full input group
- render removable multi-select chips inline with the input
- add regression coverage for option selection through the mounted demo popup

## Validation

- `pnpm fmt --check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (42 tests)
- `pnpm validate`
- `pnpm --filter @foldcn/registry run build`
- `pnpm --filter @foldcn/web build`
- `git diff --check`

Fixes #17
