### PR TITLE
pagination: port presentational landmark from base registry

### DIFF
--- a/docs/shadcn-base-parity-audit.md
+++ b/docs/shadcn-base-parity-audit.md
@@ -67,7 +67,7 @@ Beyond styling, several foldcn components are missing their **defining behaviors
 ### Not covered (no counterpart)
 
 - **foldcn-only (7):** animation, date-picker, drag-and-drop, file-drop, listbox, nav, virtual-list
-- **base-only, missing from foldcn (10):** attachment, bubble, carousel, chart, message, message-scroller, native-select (partially covered inside foldcn `select.ts`), pagination, questionnaire, scroll-area
+- **base-only, missing from foldcn (9):** attachment, bubble, carousel, chart, message, message-scroller, native-select (partially covered inside foldcn `select.ts`), questionnaire, scroll-area
 - Renames: foldcn `menu` ↔ base `dropdown-menu`; foldcn `fieldset` ↔ base `field`.
 - Manifest `ui/registry.json`: 60 entries ↔ 60 files, no mismatches.
 

--- a/packages/registry/registry/default/ui/pagination.ts
+++ b/packages/registry/registry/default/ui/pagination.ts
@@ -1,0 +1,198 @@
+// Pagination is a pure presentational landmark (a `nav`), mirroring the
+// upstream base registry: `Pagination` is the container and sub-builders are
+// attached as properties: Pagination.content, Pagination.item, Pagination.link,
+// Pagination.previous, Pagination.next, Pagination.ellipsis.
+//
+// PaginationLink reproduces upstream's anchor-styled-as-button pattern
+// (Button with `render={<a>}` / `nativeButton={false}`): it emits the button
+// token classes on an `a` element directly, with `aria-current="page"` and
+// `data-active` marking the active page.
+
+import type { Attribute, Html, HtmlBuilder } from 'foldkit/html'
+
+import { cn } from '@/lib/utils'
+import { icon } from '@/lib/icons'
+import { ChevronLeft, ChevronRight, MoreHorizontal } from 'lucide'
+
+import { buttonSizes, buttonVariants, type ButtonSize } from './button'
+
+type Child = Html | string
+
+export const paginationClass = 'cn-pagination mx-auto flex w-full justify-center'
+
+export const paginationContentClass = 'cn-pagination-content flex items-center'
+
+export const paginationLinkClass = 'cn-pagination-link'
+
+export const paginationPreviousClass = 'cn-pagination-previous'
+
+export const paginationNextClass = 'cn-pagination-next'
+
+export const paginationEllipsisClass = 'cn-pagination-ellipsis flex items-center justify-center'
+
+type StyleConfig = Readonly<{ className?: string }>
+
+export type PaginationLinkConfig<M> = Readonly<{
+  className?: string
+  /** Marks the link as the current page: outline variant, `aria-current="page"`
+   *  and `data-active="true"`. */
+  isActive?: boolean
+  /** Button size tokens; defaults to `icon` like upstream. */
+  size?: ButtonSize
+  href?: string
+  /** Extra attributes merged onto the anchor (ids, click handlers, …). */
+  attributes?: ReadonlyArray<Attribute<M>>
+}>
+
+const paginationContainer = <M>(
+  config: StyleConfig,
+  children: ReadonlyArray<Child>,
+  h: HtmlBuilder<M>,
+): Html =>
+  h.nav(
+    [
+      h.Role('navigation'),
+      h.AriaLabel('pagination'),
+      h.Class(cn(paginationClass, config.className)),
+      h.DataAttribute('slot', 'pagination'),
+    ],
+    children,
+  )
+
+const paginationContent = <M>(
+  config: StyleConfig,
+  children: ReadonlyArray<Child>,
+  h: HtmlBuilder<M>,
+): Html =>
+  h.ul(
+    [
+      h.Class(cn(paginationContentClass, config.className)),
+      h.DataAttribute('slot', 'pagination-content'),
+    ],
+    children,
+  )
+
+const paginationItem = <M>(
+  config: StyleConfig,
+  children: ReadonlyArray<Child>,
+  h: HtmlBuilder<M>,
+): Html => h.li([h.DataAttribute('slot', 'pagination-item')], children)
+
+const paginationLink = <M>(
+  config: PaginationLinkConfig<M>,
+  children: ReadonlyArray<Child>,
+  h: HtmlBuilder<M>,
+): Html => {
+  const variant = config.isActive === true ? 'outline' : 'ghost'
+  return h.a(
+    [
+      ...(config.isActive === true ? [h.AriaCurrent('page')] : []),
+      h.Href(config.href ?? '#'),
+      h.DataAttribute('slot', 'pagination-link'),
+      h.DataAttribute('active', config.isActive === true ? 'true' : 'false'),
+      h.Class(
+        cn(
+          'cn-button',
+          buttonVariants[variant],
+          buttonSizes[config.size ?? 'icon'],
+          paginationLinkClass,
+          config.className,
+        ),
+      ),
+      ...(config.attributes ?? []),
+    ],
+    children,
+  )
+}
+
+const paginationPrevious = <M>(
+  config: PaginationLinkConfig<M> & Readonly<{ text?: string }>,
+  children: ReadonlyArray<Child> = [],
+  h: HtmlBuilder<M>,
+): Html =>
+  h.a(
+    [
+      h.AriaLabel('Go to previous page'),
+      h.Href(config.href ?? '#'),
+      h.DataAttribute('slot', 'pagination-link'),
+      h.DataAttribute('active', config.isActive === true ? 'true' : 'false'),
+      h.Class(
+        cn(
+          'cn-button',
+          buttonVariants[config.isActive === true ? 'outline' : 'ghost'],
+          buttonSizes[config.size ?? 'default'],
+          paginationPreviousClass,
+          config.className,
+        ),
+      ),
+      ...(config.attributes ?? []),
+    ],
+    children.length > 0
+      ? children
+      : [
+          icon(h, ChevronLeft, 'cn-rtl-flip', 'inline-start'),
+          h.span(
+            [h.Class('cn-pagination-previous-text hidden sm:block')],
+            [config.text ?? 'Previous'],
+          ),
+        ],
+  )
+
+const paginationNext = <M>(
+  config: PaginationLinkConfig<M> & Readonly<{ text?: string }>,
+  children: ReadonlyArray<Child> = [],
+  h: HtmlBuilder<M>,
+): Html =>
+  h.a(
+    [
+      h.AriaLabel('Go to next page'),
+      h.Href(config.href ?? '#'),
+      h.DataAttribute('slot', 'pagination-link'),
+      h.DataAttribute('active', config.isActive === true ? 'true' : 'false'),
+      h.Class(
+        cn(
+          'cn-button',
+          buttonVariants[config.isActive === true ? 'outline' : 'ghost'],
+          buttonSizes[config.size ?? 'default'],
+          paginationNextClass,
+          config.className,
+        ),
+      ),
+      ...(config.attributes ?? []),
+    ],
+    children.length > 0
+      ? children
+      : [
+          h.span([h.Class('cn-pagination-next-text hidden sm:block')], [config.text ?? 'Next']),
+          icon(h, ChevronRight, 'cn-rtl-flip', 'inline-end'),
+        ],
+  )
+
+/** Ellipsis — collapsed middle pages. */
+const paginationEllipsis = <M>(
+  config: StyleConfig,
+  children: ReadonlyArray<Child> = [],
+  h: HtmlBuilder<M>,
+): Html =>
+  h.span(
+    [
+      h.AriaHidden(true),
+      h.Class(cn(paginationEllipsisClass, config.className)),
+      h.DataAttribute('slot', 'pagination-ellipsis'),
+    ],
+    children.length > 0
+      ? children
+      : [icon(h, MoreHorizontal), h.span([h.Class('sr-only')], ['More pages'])],
+  )
+
+/** Composable pagination — `Pagination` is the container, with sub-builders
+ *  as properties: `Pagination.content`, `Pagination.item`, `Pagination.link`,
+ *  `Pagination.previous`, `Pagination.next`, `Pagination.ellipsis`. */
+export const Pagination = Object.assign(paginationContainer, {
+  content: paginationContent,
+  item: paginationItem,
+  link: paginationLink,
+  previous: paginationPrevious,
+  next: paginationNext,
+  ellipsis: paginationEllipsis,
+})

--- a/packages/registry/registry/default/ui/registry.json
+++ b/packages/registry/registry/default/ui/registry.json
@@ -734,6 +734,19 @@
       ]
     },
     {
+      "name": "pagination",
+      "type": "registry:ui",
+      "title": "Pagination",
+      "description": "Presentational pagination landmark with content, item, link (button-styled anchors with active page marking), previous, next and ellipsis builders.",
+      "registryDependencies": ["@foldcn/utils", "@foldcn/icons", "@foldcn/button"],
+      "files": [
+        {
+          "path": "pagination.ts",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
       "name": "navigation-menu",
       "type": "registry:ui",
       "title": "Navigation Menu",

--- a/packages/web/src/demo/assemble.ts
+++ b/packages/web/src/demo/assemble.ts
@@ -50,6 +50,7 @@ import { slice as menubarSlice } from './views/menubar'
 import { slice as navSlice } from './views/nav'
 import { slice as nativeSelectSlice } from './views/native-select'
 import { slice as navigationMenuSlice } from './views/navigation-menu'
+import { slice as paginationSlice } from './views/pagination'
 import { slice as popoverSlice } from './views/popover'
 import { slice as progressSlice } from './views/progress'
 import { slice as radioGroupSlice } from './views/radio-group'
@@ -119,6 +120,7 @@ const ModelSchema = S.Struct({
   ...navSlice.fields,
   ...navigationMenuSlice.fields,
   ...nativeSelectSlice.fields,
+  ...paginationSlice.fields,
   ...popoverSlice.fields,
   ...progressSlice.fields,
   ...radioGroupSlice.fields,
@@ -188,6 +190,7 @@ const MessageSchema = S.Union([
   ...navSlice.messages,
   ...navigationMenuSlice.messages,
   ...nativeSelectSlice.messages,
+  ...paginationSlice.messages,
   ...popoverSlice.messages,
   ...progressSlice.messages,
   ...radioGroupSlice.messages,
@@ -261,6 +264,7 @@ export const init = (): DemoUpdateReturn => {
     ...navSlice.init,
     ...navigationMenuSlice.init,
     ...nativeSelectSlice.init,
+    ...paginationSlice.init,
     ...popoverSlice.init,
     ...progressSlice.init,
     ...radioGroupSlice.init,

--- a/packages/web/src/demo/examples.ts
+++ b/packages/web/src/demo/examples.ts
@@ -30,6 +30,7 @@ import markerViewSource from './views/marker.ts?raw'
 import menuViewSource from './views/menu.ts?raw'
 import nativeSelectViewSource from './views/native-select.ts?raw'
 import navViewSource from './views/nav.ts?raw'
+import paginationViewSource from './views/pagination.ts?raw'
 import popoverViewSource from './views/popover.ts?raw'
 import progressViewSource from './views/progress.ts?raw'
 import radioGroupViewSource from './views/radio-group.ts?raw'
@@ -222,6 +223,11 @@ export const demoExampleByName: Readonly<Record<DemoItemName, DemoExample>> = {
     path: 'src/demo/views/nav.ts',
     code: navViewSource,
     githubUrl: gh('src/demo/views/nav.ts'),
+  },
+  pagination: {
+    path: 'src/demo/views/pagination.ts',
+    code: paginationViewSource,
+    githubUrl: gh('src/demo/views/pagination.ts'),
   },
   popover: {
     path: 'src/demo/views/popover.ts',

--- a/packages/web/src/demo/views/pagination.ts
+++ b/packages/web/src/demo/views/pagination.ts
@@ -1,0 +1,97 @@
+// Sections mirror apps/v4/examples/base/pagination-{demo,simple,icons-only}.tsx.
+// Pagination is fully presentational — no state, no messages; the slice is
+// empty but keeps the harness contract (fields/init/messages/handlers).
+
+import type { Html, HtmlBuilder } from 'foldkit/html'
+
+import { Pagination } from '../../generated/registry/ui/pagination'
+
+import { defineSlice } from '../slice'
+import type { Message, Model } from '../assemble'
+
+const section = (h: HtmlBuilder<Message>, label: string, content: Html): Html =>
+  h.div(
+    [h.Class('flex w-full flex-col gap-2')],
+    [h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], [label]), content],
+  )
+
+export const paginationView = (_model: Model, h: HtmlBuilder<Message>): Html =>
+  h.div(
+    [h.Class('flex w-full flex-col gap-8')],
+    [
+      section(
+        h,
+        'Basic',
+        Pagination(
+          {},
+          [
+            Pagination.content(
+              {},
+              [
+                Pagination.item({}, [Pagination.previous({}, [], h)], h),
+                Pagination.item({}, [Pagination.link({}, ['1'], h)], h),
+                Pagination.item({}, [Pagination.link({ isActive: true }, ['2'], h)], h),
+                Pagination.item({}, [Pagination.link({}, ['3'], h)], h),
+                Pagination.item({}, [Pagination.ellipsis({}, [], h)], h),
+                Pagination.item({}, [Pagination.next({}, [], h)], h),
+              ],
+              h,
+            ),
+          ],
+          h,
+        ),
+      ),
+      section(
+        h,
+        'Simple',
+        Pagination(
+          {},
+          [
+            Pagination.content(
+              {},
+              [
+                Pagination.item({}, [Pagination.link({}, ['1'], h)], h),
+                Pagination.item({}, [Pagination.link({ isActive: true }, ['2'], h)], h),
+                Pagination.item({}, [Pagination.link({}, ['3'], h)], h),
+                Pagination.item({}, [Pagination.link({}, ['4'], h)], h),
+                Pagination.item({}, [Pagination.link({}, ['5'], h)], h),
+              ],
+              h,
+            ),
+          ],
+          h,
+        ),
+      ),
+      section(
+        h,
+        'Icons Only',
+        h.div(
+          [h.Class('flex items-center justify-between gap-4')],
+          [
+            h.div([h.Class('text-sm text-muted-foreground')], ['Rows per page: 25']),
+            Pagination(
+              { className: 'mx-0 w-auto' },
+              [
+                Pagination.content(
+                  {},
+                  [
+                    Pagination.item({}, [Pagination.previous({}, [], h)], h),
+                    Pagination.item({}, [Pagination.next({}, [], h)], h),
+                  ],
+                  h,
+                ),
+              ],
+              h,
+            ),
+          ],
+        ),
+      ),
+    ],
+  )
+
+export const slice = defineSlice({
+  fields: {},
+  init: {},
+  messages: [],
+  handlers: () => ({}),
+})


### PR DESCRIPTION
## What

Ports the upstream shadcn/ui v4 base `pagination` component (`apps/v4/registry/bases/base/ui/pagination.tsx`) to foldcn, per the recipe in `docs/deriving-from-base.md`.

**Component — `packages/registry/registry/default/ui/pagination.ts`**
- Presentational landmark (no state machine): `Pagination` is a `nav` with `role="navigation"` / `aria-label="pagination"`, with sub-builders attached as properties — `Pagination.content` (ul), `Pagination.item` (li), `Pagination.link`, `Pagination.previous`, `Pagination.next`, `Pagination.ellipsis` — following the breadcrumb Object.assign pattern (ADR-011).
- `PaginationLink` reproduces upstream's anchor-styled-as-button pattern (`Button` with `render={<a>}` + `nativeButton={false}`) by emitting the `cn-button` + variant + size tokens directly on an `<a>`, reusing `buttonVariants`/`buttonSizes` imported from `./button` (same cross-component-import precedent as command → input-group/dialog, declared as `registryDependencies`).
- Active page marking matches upstream exactly: outline variant, `aria-current="page"`, `data-active="true"` (inactive links get `data-active="false"`, mirroring React's stringified data attributes).
- Same `data-slot` names as upstream on every part; previous/next icons render via `@/lib/icons` with `cn-rtl-flip` and `data-icon` inline-start/end; the `hidden sm:block` text spans are kept character-identical to upstream (upstream-inlined literals, not tokens).
- Authored source emits only `cn-*` tokens. `cn-pagination`, `cn-pagination-link`, and the `-previous-text`/`-next-text` tokens are known upstream no-op hooks — the resolver strips them with its standard warning, matching upstream's deliberate unstyled behavior.

**Registration — `registry/default/ui/registry.json`**
- `registry:ui` item with title, description, `registryDependencies: ["@foldcn/utils", "@foldcn/icons", "@foldcn/button"]`, and the single file entry.

**Demo — `packages/web/src/demo/views/pagination.ts`**
- Empty slice (pagination is fully presentational — no fields, no messages), mirroring upstream's `pagination-demo`, `pagination-simple`, and `pagination-icons-only` examples as three labelled sections.
- Wired into `demo/assemble.ts` (fields/messages/init spreads; no handler entry since there are no messages) and `demo/examples.ts` (raw-source code display). `demo/view.ts` picked it up automatically via its glob.

**Docs — `docs/shadcn-base-parity-audit.md`**
- Pagination removed from the "base-only, missing from foldcn" list (10 → 9).

## Why

Closes the gap between foldcn and the upstream base registry for this component. The catalog now lists pagination as **Full parity** — no `catalog/gaps.ts` entry needed: foldkit emits everything upstream requires here (plain anchors, `aria-current`, data attributes), nothing was dropped or approximated.

## Verification

- `pnpm --filter @foldcn/registry run build` — passes. Resolved `styles/default/ui/pagination.ts` contains zero `cn-*` literals; tokens substitute correctly (`cn-pagination-ellipsis` → nova `size-8` + svg sizing, `cn-rtl-flip` → `rtl:rotate-180`, button tokens → full nova utilities).
- `pnpm --filter @foldcn/registry run validate` — registry valid.
- `pnpm typecheck` and `pnpm test` — all pass (39/39). One earlier `command-behavior.test.ts` timeout also failed on the clean base commit (verified via `git stash`), confirming it was pre-existing flake, not this change.
- Demo rendered live at `/docs/pagination` via the dev server and screenshot-verified: all three sections (Basic with active outlined page and ellipsis, Simple, Icons Only) style correctly, the install command (`npx shadcn@latest add @foldcn/pagination`) and both source snippets (component + demo) display, and the item appears in the components index.
