### PR TITLE
Port bubble from upstream base registry

### DIFF
--- a/packages/registry/registry/default/ui/bubble.ts
+++ b/packages/registry/registry/default/ui/bubble.ts
@@ -1,0 +1,157 @@
+import type { Attribute, Html, HtmlBuilder } from 'foldkit/html'
+
+type Child = Html | string
+
+import { cn } from '@/lib/utils'
+
+/** Bubble variant keys. Sync with `bubbleVariants` is compiler-enforced:
+ *  `bubbleVariants` is `Record<BubbleVariant, string>` (missing key = error)
+ *  and annotated object literals reject unknown keys. */
+export const bubbleVariantKeys = [
+  'default',
+  'secondary',
+  'muted',
+  'tinted',
+  'outline',
+  'ghost',
+  'destructive',
+] as const
+
+export type BubbleVariant = (typeof bubbleVariantKeys)[number]
+
+export const bubbleVariants: Record<BubbleVariant, string> = {
+  default: 'cn-bubble-variant-default',
+  secondary: 'cn-bubble-variant-secondary',
+  muted: 'cn-bubble-variant-muted',
+  tinted: 'cn-bubble-variant-tinted',
+  outline: 'cn-bubble-variant-outline',
+  ghost: 'cn-bubble-variant-ghost',
+  destructive: 'cn-bubble-variant-destructive',
+}
+
+export type BubbleAlign = 'start' | 'end'
+
+export type BubbleReactionsSide = 'top' | 'bottom'
+
+export const bubbleClass = 'cn-bubble group/bubble relative flex w-fit min-w-0 flex-col'
+
+export const bubbleGroupClass = 'cn-bubble-group flex min-w-0 flex-col'
+
+export const bubbleContentClass =
+  'cn-bubble-content w-fit max-w-full min-w-0 overflow-hidden wrap-break-word [button]:text-left [button,a]:transition-colors'
+
+export const bubbleReactionsClass =
+  'cn-bubble-reactions absolute z-10 flex w-fit items-center justify-center'
+
+export const bubbleReactionsSideClasses: Record<BubbleReactionsSide, string> = {
+  top: 'cn-bubble-reactions-side-top',
+  bottom: 'cn-bubble-reactions-side-bottom',
+}
+
+export const bubbleReactionsAlignClasses: Record<BubbleAlign, string> = {
+  start: 'cn-bubble-reactions-align-start',
+  end: 'cn-bubble-reactions-align-end',
+}
+
+type BubbleConfig = Readonly<{
+  className?: string
+  variant?: BubbleVariant
+  align?: BubbleAlign
+}>
+
+const bubbleGroup = <M>(
+  config: Readonly<{ className?: string }>,
+  children: ReadonlyArray<Child>,
+  h: HtmlBuilder<M>,
+): Html =>
+  h.div(
+    [h.Class(cn(bubbleGroupClass, config.className)), h.DataAttribute('slot', 'bubble-group')],
+    children,
+  )
+
+const bubbleContainer = <M>(
+  config: BubbleConfig,
+  children: ReadonlyArray<Child>,
+  h: HtmlBuilder<M>,
+): Html =>
+  h.div(
+    [
+      h.Class(cn(bubbleClass, bubbleVariants[config.variant ?? 'default'], config.className)),
+      h.DataAttribute('slot', 'bubble'),
+      h.DataAttribute('variant', config.variant ?? 'default'),
+      h.DataAttribute('align', config.align ?? 'start'),
+    ],
+    children,
+  )
+
+export type BubbleContentConfig<M> = Readonly<{
+  className?: string
+  /** Element to render as — foldcn's stand-in for upstream's `useRender`
+   *  `render` prop. Button/anchor bubbles keep the same content classes,
+   *  including the variant hover state keyed on the content element itself. */
+  as?: 'div' | 'button' | 'a'
+  /** Click message when rendered `as: 'button'`. */
+  onClick?: M
+  /** Extra attributes merged onto the content element (href, labels, …). */
+  attributes?: ReadonlyArray<Attribute<M>>
+}>
+
+const bubbleContent = <M>(
+  config: BubbleContentConfig<M>,
+  children: ReadonlyArray<Child>,
+  h: HtmlBuilder<M>,
+): Html => {
+  const attributes: ReadonlyArray<Attribute<M>> = [
+    h.Class(cn(bubbleContentClass, config.className)),
+    h.DataAttribute('slot', 'bubble-content'),
+    ...(config.attributes ?? []),
+  ]
+  if (config.as === 'button')
+    return h.button(
+      [...attributes, ...(config.onClick ? [h.OnClick(config.onClick)] : [])],
+      children,
+    )
+  if (config.as === 'a') return h.a(attributes, children)
+  return h.div(attributes, children)
+}
+
+export type BubbleReactionsConfig<M> = Readonly<{
+  side?: BubbleReactionsSide
+  align?: BubbleAlign
+  className?: string
+  /** Extra attributes merged onto the reactions element (role, labels, …). */
+  attributes?: ReadonlyArray<Attribute<M>>
+}>
+
+const bubbleReactions = <M>(
+  config: BubbleReactionsConfig<M>,
+  children: ReadonlyArray<Child>,
+  h: HtmlBuilder<M>,
+): Html => {
+  const side = config.side ?? 'bottom'
+  const align = config.align ?? 'end'
+  return h.div(
+    [
+      h.Class(
+        cn(
+          bubbleReactionsClass,
+          bubbleReactionsSideClasses[side],
+          bubbleReactionsAlignClasses[align],
+          config.className,
+        ),
+      ),
+      h.DataAttribute('slot', 'bubble-reactions'),
+      h.DataAttribute('align', align),
+      h.DataAttribute('side', side),
+    ],
+    children,
+  )
+}
+
+/** Styled chat bubble — `Bubble.group`, `Bubble.content` and
+ *  `Bubble.reactions` sub-builders. Mirrors the shadcn v4 `bubble.tsx`. */
+export const Bubble = Object.assign(bubbleContainer, {
+  group: bubbleGroup,
+  content: bubbleContent,
+  reactions: bubbleReactions,
+})

--- a/packages/registry/registry/default/ui/registry.json
+++ b/packages/registry/registry/default/ui/registry.json
@@ -819,6 +819,19 @@
           "type": "registry:ui"
         }
       ]
+    },
+    {
+      "name": "bubble",
+      "type": "registry:ui",
+      "title": "Bubble",
+      "description": "Styled chat bubble with group, content and reactions sub-builders, variants and start/end alignment.",
+      "registryDependencies": ["@foldcn/utils"],
+      "files": [
+        {
+          "path": "bubble.ts",
+          "type": "registry:ui"
+        }
+      ]
     }
   ]
 }

--- a/packages/web/src/catalog/gaps.ts
+++ b/packages/web/src/catalog/gaps.ts
@@ -47,6 +47,9 @@ export const gapsByItem = {
     'Numeric codes only — non-digits are stripped with no pattern or alphanumeric mode like upstream.',
     'onInput fires on every change; onComplete alone doubles as the update channel, so derive completion from the stored value.',
   ],
+  bubble: [
+    "BubbleContent supports `as: 'div' | 'button' | 'a'` in place of upstream's render prop — other element substitutions need a manual wrapper.",
+  ],
 } as const
 
 const isGapItem = (name: string): name is keyof typeof gapsByItem => name in gapsByItem

--- a/packages/web/src/demo/assemble.ts
+++ b/packages/web/src/demo/assemble.ts
@@ -16,6 +16,7 @@ import { slice as attachmentSlice } from './views/attachment'
 import { slice as avatarSlice } from './views/avatar'
 import { slice as badgeSlice } from './views/badge'
 import { slice as breadcrumbSlice } from './views/breadcrumb'
+import { slice as bubbleSlice } from './views/bubble'
 import { slice as buttonGroupSlice } from './views/button-group'
 import { slice as buttonSlice } from './views/button'
 import { slice as calendarSlice } from './views/calendar'
@@ -85,6 +86,7 @@ const ModelSchema = S.Struct({
   ...avatarSlice.fields,
   ...badgeSlice.fields,
   ...breadcrumbSlice.fields,
+  ...bubbleSlice.fields,
   ...buttonGroupSlice.fields,
   ...buttonSlice.fields,
   ...calendarSlice.fields,
@@ -154,6 +156,7 @@ const MessageSchema = S.Union([
   ...avatarSlice.messages,
   ...badgeSlice.messages,
   ...breadcrumbSlice.messages,
+  ...bubbleSlice.messages,
   ...buttonGroupSlice.messages,
   ...buttonSlice.messages,
   ...calendarSlice.messages,
@@ -227,6 +230,7 @@ export const init = (): DemoUpdateReturn => {
     ...avatarSlice.init,
     ...badgeSlice.init,
     ...breadcrumbSlice.init,
+    ...bubbleSlice.init,
     ...buttonGroupSlice.init,
     ...buttonSlice.init,
     ...calendarSlice.init,
@@ -294,6 +298,7 @@ export const update = (model: Model, message: Message): DemoUpdateReturn => {
     M.tagsExhaustive({
       ...accordionSlice.handlers(model),
       ...alertDialogSlice.handlers(model),
+      ...bubbleSlice.handlers(model),
       ...breadcrumbSlice.handlers(model),
       ...animationSlice.handlers(model),
       ...avatarSlice.handlers(model),

--- a/packages/web/src/demo/examples.ts
+++ b/packages/web/src/demo/examples.ts
@@ -6,6 +6,7 @@ import aspectRatioViewSource from './views/aspect-ratio.ts?raw'
 import attachmentViewSource from './views/attachment.ts?raw'
 import avatarViewSource from './views/avatar.ts?raw'
 import badgeViewSource from './views/badge.ts?raw'
+import bubbleViewSource from './views/bubble.ts?raw'
 import buttonViewSource from './views/button.ts?raw'
 import calendarViewSource from './views/calendar.ts?raw'
 import cardViewSource from './views/card.ts?raw'
@@ -107,6 +108,11 @@ export const demoExampleByName: Readonly<Record<DemoItemName, DemoExample>> = {
     path: 'src/demo/views/badge.ts',
     code: badgeViewSource,
     githubUrl: gh('src/demo/views/badge.ts'),
+  },
+  bubble: {
+    path: 'src/demo/views/bubble.ts',
+    code: bubbleViewSource,
+    githubUrl: gh('src/demo/views/bubble.ts'),
   },
   button: {
     path: 'src/demo/views/button.ts',

--- a/packages/web/src/demo/views/bubble.ts
+++ b/packages/web/src/demo/views/bubble.ts
@@ -1,0 +1,506 @@
+import { Schema as S } from 'effect'
+import { defineMessageUnion } from 'foldkit/message'
+import type { Html, HtmlBuilder } from 'foldkit/html'
+import { evo } from 'foldkit/struct'
+
+import { Bubble } from '../../generated/registry/ui/bubble'
+import { button } from '../../generated/registry/ui/button'
+import { Marker } from '../../generated/registry/ui/marker'
+import { icon } from '../../generated/registry/lib/icons'
+import { ThumbsUp, ThumbsDown, PartyPopper } from 'lucide'
+
+import { defineSlice, type UpdateReturn } from '../slice'
+import type { Model, Message as AppMessage } from '../assemble'
+
+const Message = defineMessageUnion({
+  PickedReply: { text: S.String },
+  ToggledReaction: {},
+})
+
+const quickReplies = [
+  'I need help with my account.',
+  'I forgot my password.',
+  'I have another question. I would like to talk to a human. Can you help me?',
+]
+
+export const bubbleView = (model: Model, h: HtmlBuilder<AppMessage>): Html => {
+  const separatorMarker = (label: string): Html =>
+    Marker<AppMessage>({ variant: 'separator' }, [Marker.content<AppMessage>({}, [label], h)], h)
+
+  const section = (label: string, children: ReadonlyArray<Html>): Html =>
+    h.div(
+      [h.Class('flex w-full flex-col gap-2')],
+      [h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], [label]), ...children],
+    )
+
+  return h.div(
+    [h.Class('flex w-full max-w-md flex-col gap-8 py-12')],
+    [
+      section('Variants', [
+        Bubble<AppMessage>(
+          {},
+          [
+            Bubble.content<AppMessage>(
+              {},
+              ['Default bubbles use the primary color for the active user side of a chat.'],
+              h,
+            ),
+          ],
+          h,
+        ),
+        Bubble<AppMessage>(
+          { variant: 'secondary' },
+          [
+            Bubble.content<AppMessage>(
+              {},
+              ['Secondary bubbles are the standard neutral surface for assistant content.'],
+              h,
+            ),
+          ],
+          h,
+        ),
+        Bubble<AppMessage>(
+          { variant: 'muted' },
+          [
+            Bubble.content<AppMessage>(
+              {},
+              ['Muted bubbles lower the emphasis for quiet system notes.'],
+              h,
+            ),
+          ],
+          h,
+        ),
+        Bubble<AppMessage>(
+          { variant: 'tinted', align: 'end' },
+          [
+            Bubble.content<AppMessage>(
+              {},
+              ['Tinted bubbles use a softer primary tint when primary fill is too strong.'],
+              h,
+            ),
+          ],
+          h,
+        ),
+        Bubble<AppMessage>(
+          { variant: 'outline' },
+          [
+            Bubble.content<AppMessage>(
+              {},
+              ['Outline bubbles can be used to frame message content and give it a border.'],
+              h,
+            ),
+          ],
+          h,
+        ),
+        Bubble<AppMessage>(
+          { variant: 'destructive' },
+          [
+            Bubble.content<AppMessage>(
+              {},
+              ['Destructive bubbles flag errors or failed actions in a conversation.'],
+              h,
+            ),
+          ],
+          h,
+        ),
+        Bubble<AppMessage>(
+          { variant: 'ghost' },
+          [
+            Bubble.content<AppMessage>(
+              {},
+              [
+                h.span(
+                  [h.Class('whitespace-pre-wrap')],
+                  [
+                    'Ghost bubbles work for assistant text that should not be framed.\n\nThey are full width and can take the whole row of the conversation.',
+                  ],
+                ),
+              ],
+              h,
+            ),
+          ],
+          h,
+        ),
+      ]),
+      section('Sizes', [
+        Bubble<AppMessage>(
+          {},
+          [Bubble.content<AppMessage>({}, ['This is a one line bubble.'], h)],
+          h,
+        ),
+        Bubble<AppMessage>(
+          {},
+          [
+            Bubble.content<AppMessage>(
+              {},
+              [
+                'This bubble has multiple lines. It should wrap to the next line and you should see a different radius on the corners.',
+              ],
+              h,
+            ),
+          ],
+          h,
+        ),
+        Bubble<AppMessage>(
+          {},
+          [
+            Bubble.content<AppMessage>(
+              {},
+              [
+                h.p([], ['This bubble has multiple lines.']),
+                h.p(
+                  [],
+                  [
+                    'It should wrap to the next line and you should see a different radius on the corners.',
+                  ],
+                ),
+                h.p([], ['Here is some more text to see how it wraps.']),
+              ],
+              h,
+            ),
+          ],
+          h,
+        ),
+      ]),
+      section('Alignment', [
+        Bubble<AppMessage>(
+          { variant: 'muted' },
+          [Bubble.content<AppMessage>({}, ['This bubble is aligned to the start.'], h)],
+          h,
+        ),
+        Bubble<AppMessage>(
+          { align: 'end' },
+          [Bubble.content<AppMessage>({}, ['This bubble is aligned to the end.'], h)],
+          h,
+        ),
+        Bubble<AppMessage>(
+          { variant: 'muted' },
+          [
+            Bubble.content<AppMessage>(
+              {},
+              [
+                'This multiline bubble is aligned to the start. The corners should adjust when the text wraps to show the grouped side of the conversation.',
+              ],
+              h,
+            ),
+          ],
+          h,
+        ),
+        Bubble<AppMessage>(
+          { align: 'end' },
+          [
+            Bubble.content<AppMessage>(
+              {},
+              [
+                'This multiline bubble is aligned to the end. It should sit on the opposite side with the matching corner radius for wrapped text.',
+              ],
+              h,
+            ),
+          ],
+          h,
+        ),
+      ]),
+      section('Grouped', [
+        Bubble.group<AppMessage>(
+          {},
+          [
+            Bubble<AppMessage>(
+              { variant: 'secondary' },
+              [Bubble.content<AppMessage>({}, ['I finished the audit pass.'], h)],
+              h,
+            ),
+            Bubble<AppMessage>(
+              { variant: 'secondary' },
+              [
+                Bubble.content<AppMessage>(
+                  {},
+                  ['The registry output looks clean, but I found one stale route.'],
+                  h,
+                ),
+              ],
+              h,
+            ),
+            Bubble<AppMessage>(
+              { variant: 'secondary' },
+              [Bubble.content<AppMessage>({}, ['Want me to remove it now?'], h)],
+              h,
+            ),
+          ],
+          h,
+        ),
+        Bubble.group<AppMessage>(
+          {},
+          [
+            Bubble<AppMessage>(
+              { variant: 'tinted', align: 'end' },
+              [Bubble.content<AppMessage>({}, ['Yes, clean that up.'], h)],
+              h,
+            ),
+            Bubble<AppMessage>(
+              { variant: 'tinted', align: 'end' },
+              [Bubble.content<AppMessage>({}, ['Then rerun the registry build.'], h)],
+              h,
+            ),
+          ],
+          h,
+        ),
+      ]),
+      section('Buttons & Links', [
+        Bubble<AppMessage>(
+          {},
+          [
+            Bubble.content<AppMessage>(
+              { as: 'a', attributes: [h.Href('#')] },
+              ['This bubble is a link.'],
+              h,
+            ),
+          ],
+          h,
+        ),
+        Bubble<AppMessage>(
+          { variant: 'secondary' },
+          [
+            Bubble.content<AppMessage>(
+              { as: 'button' },
+              ['This one is a button you can click.'],
+              h,
+            ),
+          ],
+          h,
+        ),
+        Bubble<AppMessage>(
+          { variant: 'muted' },
+          [
+            Bubble.content<AppMessage>(
+              { as: 'button' },
+              ['You can also do tinted buttons. Even ones that are multilines.'],
+              h,
+            ),
+          ],
+          h,
+        ),
+        separatorMarker('Chat Suggestions'),
+        Bubble<AppMessage>(
+          {},
+          [Bubble.content<AppMessage>({}, ['How can I help you today?'], h)],
+          h,
+        ),
+        Bubble.group<AppMessage>(
+          {},
+          [
+            ...quickReplies.map((reply) =>
+              Bubble<AppMessage>(
+                { variant: 'outline', align: 'end' },
+                [
+                  Bubble.content<AppMessage>(
+                    {
+                      as: 'button',
+                      className: 'border-dashed border-primary',
+                      onClick: Message.PickedReply({ text: reply }),
+                    },
+                    [reply],
+                    h,
+                  ),
+                ],
+                h,
+              ),
+            ),
+          ],
+          h,
+        ),
+        ...model.bubbleReplies.map((reply) =>
+          Bubble<AppMessage>(
+            { variant: 'secondary', align: 'end' },
+            [Bubble.content<AppMessage>({}, [reply], h)],
+            h,
+          ),
+        ),
+      ]),
+      section('Reaction Placement', [
+        separatorMarker('side=bottom align=end'),
+        Bubble<AppMessage>(
+          {},
+          [
+            Bubble.content<AppMessage>({}, ['This is a one line message.'], h),
+            Bubble.reactions<AppMessage>(
+              {
+                side: 'bottom',
+                align: 'end',
+                attributes: [h.Attribute('role', 'img'), h.AriaLabel('Reaction: thumbs up')],
+              },
+              [h.span([], ['👍'])],
+              h,
+            ),
+          ],
+          h,
+        ),
+        Bubble<AppMessage>(
+          { variant: 'secondary', align: 'end' },
+          [
+            Bubble.content<AppMessage>(
+              {},
+              [
+                'A longer message that wraps across lines so the reaction offset is easier to inspect.',
+              ],
+              h,
+            ),
+            Bubble.reactions<AppMessage>(
+              {
+                side: 'bottom',
+                align: 'start',
+                attributes: [
+                  h.Attribute('role', 'img'),
+                  h.AriaLabel('Reactions: thumbs up, surprised'),
+                ],
+              },
+              [h.span([], ['👍']), h.span([], ['😮'])],
+              h,
+            ),
+          ],
+          h,
+        ),
+        separatorMarker('side=top align=start'),
+        Bubble<AppMessage>(
+          { variant: 'secondary' },
+          [
+            Bubble.content<AppMessage>(
+              {},
+              [
+                'A longer message that wraps across lines so the reaction offset is easier to inspect.',
+              ],
+              h,
+            ),
+            Bubble.reactions<AppMessage>(
+              {
+                side: 'top',
+                align: 'start',
+                attributes: [
+                  h.Attribute('role', 'img'),
+                  h.AriaLabel('Reactions: thumbs up, surprised, fire, eyes'),
+                ],
+              },
+              [h.span([], ['👍']), h.span([], ['😮']), h.span([], ['🔥']), h.span([], ['👀'])],
+              h,
+            ),
+          ],
+          h,
+        ),
+        separatorMarker('side=top align=end'),
+        Bubble<AppMessage>(
+          { variant: 'muted' },
+          [
+            Bubble.content<AppMessage>({}, ['This is a one line message.'], h),
+            Bubble.reactions<AppMessage>(
+              {
+                side: 'top',
+                align: 'end',
+                attributes: [h.Attribute('role', 'img'), h.AriaLabel('Reaction: thumbs up')],
+              },
+              [h.span([], ['👍'])],
+              h,
+            ),
+          ],
+          h,
+        ),
+      ]),
+      section('Reaction Buttons', [
+        Bubble<AppMessage>(
+          {},
+          [
+            Bubble.content<AppMessage>({}, ['This is a one line message.'], h),
+            Bubble.reactions<AppMessage>(
+              {},
+              [button<AppMessage>({ variant: 'outline', size: 'xs' }, 'Button', h)],
+              h,
+            ),
+          ],
+          h,
+        ),
+        Bubble<AppMessage>(
+          { align: 'end' },
+          [
+            Bubble.content<AppMessage>({}, ['This is a one line message.'], h),
+            Bubble.reactions<AppMessage>(
+              { align: 'start' },
+              [
+                button<AppMessage>(
+                  {
+                    variant: 'ghost',
+                    size: 'icon-xs',
+                    attributes: [h.AriaLabel('Confetti')],
+                  },
+                  icon(h, PartyPopper, 'size-3'),
+                  h,
+                ),
+              ],
+              h,
+            ),
+          ],
+          h,
+        ),
+        Bubble<AppMessage>(
+          { variant: 'tinted' },
+          [
+            Bubble.content<AppMessage>(
+              {},
+              ['We are going to the movies first then dinner. Are you in?'],
+              h,
+            ),
+            Bubble.reactions<AppMessage>(
+              { className: 'gap-1 bg-background' },
+              [
+                button<AppMessage>(
+                  {
+                    variant: model.bubbleReacted ? 'secondary' : 'outline',
+                    size: 'icon-xs',
+                    attributes: [
+                      h.AriaLabel('Thumbs up'),
+                      h.Attribute('aria-pressed', String(model.bubbleReacted)),
+                    ],
+                    onClick: Message.ToggledReaction(),
+                  },
+                  icon(h, ThumbsUp, 'size-3'),
+                  h,
+                ),
+                button<AppMessage>(
+                  {
+                    variant: 'secondary',
+                    size: 'icon-xs',
+                    attributes: [h.AriaLabel('Thumbs down')],
+                  },
+                  icon(h, ThumbsDown, 'size-3'),
+                  h,
+                ),
+              ],
+              h,
+            ),
+          ],
+          h,
+        ),
+      ]),
+    ],
+  )
+}
+
+const fields = {
+  bubbleReplies: S.Array(S.String),
+  bubbleReacted: S.Boolean,
+}
+
+const stateSchema = S.Struct(fields)
+type State = typeof stateSchema.Type
+
+export const slice = defineSlice({
+  fields,
+  init: { bubbleReplies: [], bubbleReacted: false },
+  messages: [Message.PickedReply, Message.ToggledReaction],
+  handlers: (model: State) => ({
+    PickedReply: (payload: typeof Message.PickedReply.Type): UpdateReturn => ({
+      model: evo(model, { bubbleReplies: () => [...model.bubbleReplies, payload.text] }),
+    }),
+    ToggledReaction: (): UpdateReturn => ({
+      model: evo(model, { bubbleReacted: () => !model.bubbleReacted }),
+    }),
+  }),
+  samples: [Message.ToggledReaction()],
+})


### PR DESCRIPTION
# Port `bubble` from upstream base registry

Ports the shadcn/ui **Bubble** component from `apps/v4/registry/bases/base/ui/bubble.tsx` into foldcn, following `docs/deriving-from-base.md` (ADR-014 derivation recipe). Scope: bubble plus its demo — no other components touched, no merge of anything else.

## What's in the port

**Component — `packages/registry/registry/default/ui/bubble.ts`** (new)

- Class strings are character-identical to upstream; authoring uses only `cn-*` tokens (`cn-bubble`, the 7 `cn-bubble-variant-*`, `cn-bubble-reactions` + its side/align tokens, `cn-bubble-group`). All 15 tokens are already defined in every vendored `registry/styles/style-*.css`, so **no `cn-compat.css` deltas were needed** and the vendored CSS is untouched.
- Foldcn shape: a single `Bubble` export with `Bubble.group` / `Bubble.content` / `Bubble.reactions` sub-builders (same `Object.assign` pattern as Marker/Kbd/Item), emitting the same `data-slot` names as upstream plus `data-variant`, `data-align` (bubble) and `data-align`/`data-side` (reactions).
- All 7 variants (`default`, `secondary`, `muted`, `tinted`, `outline`, `ghost`, `destructive`), `align: start | end`, and reaction `side: top | bottom` × `align: start | end` placement.
- Upstream's `useRender` render prop maps to a `Bubble.content` config: `as: 'div' | 'button' | 'a'` (default `div`), with `onClick` and extra attributes. Button/anchor bubbles keep the variant hover styles because those tokens key on the content element itself (`[&>[data-slot=bubble-content]:is(button,a):hover]`), and the `[button]:text-left`/`[button,a]:transition-colors` descendant classes keep working for wrapped interactive children.

**Registration — `packages/registry/registry/default/ui/registry.json`**

- `bubble` entry with title, description, `registryDependencies: ["@foldcn/utils"]`, and its file. The root registry aggregates via `include`; the site catalog, parity dot, and install UI all derive automatically — nothing else to register.

**Demo — `packages/web/src/demo/views/bubble.ts`** (new)

- Slice fields `bubbleReplies` / `bubbleReacted`; messages `PickedReply` / `ToggledReaction`.
- View sections: Variants (all 7, including multiline ghost), Sizes (wrap radii), Alignment (start/end with corner-radius change), Grouped (secondary + tinted groups), Buttons & Links (link bubble via `as: 'a'`, inert button bubbles, clickable dashed-outline quick replies that append sent bubbles), Reaction Placement (all four side/align combos with Marker separators, mirroring upstream's example), and Reaction Buttons (outline/ghost buttons plus an interactive thumbs-up toggle).
- Wired into `demo/assemble.ts` (fields / messages / init / `tagsExhaustive` handlers) and `demo/examples.ts` (`?raw` code display). `demo/bundles.ts` needed no changes.

**Catalog gap — `packages/web/src/catalog/gaps.ts`**

- `bubble: ["BubbleContent supports as: 'div' | 'button' | 'a' in place of upstream's render prop — other element substitutions need a manual wrapper."]` — the sidebar dot flips to "Deviations" and the item page shows the caveat callout.

## Verification

- `pnpm --filter @foldcn/registry run build` — 69 items × 9 style catalogs; zero unresolved tokens for bubble (only the pre-existing `cn-pagination*` no-op warnings remain); resolved tree contains no `cn-*` literals; all 8 styles resolve the bubble tokens.
- `pnpm --filter @foldcn/registry run validate` — registry valid (69 items).
- `pnpm typecheck` — all packages pass.
- `pnpm test` — 39/39 pass.
- Demo verified live in a headless browser at `/docs/bubble`:
  - all sections render with correct variant surfaces and alignments;
  - clicking a quick reply appends a sent bubble (DOM count 0 → 1) — foldkit `OnClick` over the button-mode content works;
  - thumbs-up toggles variant `outline → secondary` with `aria-pressed` flipping `false → true`;
  - reactions land in the correct corners for all four side/align combos.
- `pnpm fmt` clean; pre-commit fmt/lint hooks passed.

## Not covered (documented, not silently dropped)

- Upstream's collapsible "Show more" example isn't reproduced in the demo. Foldcn's collapsible component exists; this follows the repo convention of demos being lighter than upstream examples (component surface is unaffected).
- The render-prop caveat above is the only behavioral divergence and is recorded in the gaps file rather than being silently dropped.
