### PR TITLE
port carousel from upstream base registry (embla engine)

### DIFF
--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -26,6 +26,7 @@
     "@types/node": "^26.4.0",
     "cn": "^0.2.4",
     "effect": "4.0.0-rc.112",
+    "embla-carousel": "^8.6.0",
     "foldkit": "^0.156.0",
     "lucide": "^1.37.0",
     "postcss": "^8.5.26",

--- a/packages/registry/registry/default/style/cn-compat.css
+++ b/packages/registry/registry/default/style/cn-compat.css
@@ -274,25 +274,3 @@
 .cn-command-item-indicator {
   @apply size-4 shrink-0 ml-auto opacity-0 group-has-data-[slot=command-shortcut]/command-item:hidden group-data-[checked=true]/command-item:opacity-100;
 }
-
-/* carousel: the embla engine (upstream) becomes a native scroll-snap scroll
- * port under foldkit. Upstream's viewport string is a bare "overflow-hidden";
- * the token below carries that literal plus the scroll behaviors, so the
- * component can reference a single token per axis without fighting cn's
- * last-wins merge (an overflow-hidden literal after the token would strip
- * overflow-x-auto). Slide spacing is paired (-ml-4 on the track, pl-4 on
- * items, default 1rem) — the negative scroll margin below cancels a slide's
- * inline/block-start padding so snap positions land on slide CONTENT, and
- * --foldcn-carousel-spacing (set inline by the component view) keeps the
- * pairing exact for non-default spacing like -ml-1/pl-1. */
-.cn-carousel-content {
-  @apply no-scrollbar snap-x snap-mandatory overflow-hidden overflow-x-auto overscroll-x-contain;
-}
-
-.cn-carousel-content-vertical {
-  @apply no-scrollbar snap-y snap-mandatory overflow-x-hidden overflow-y-auto overscroll-y-contain;
-}
-
-.cn-carousel-item {
-  @apply snap-start [scroll-margin-block-start:calc(var(--foldcn-carousel-spacing,1rem)*-1)] [scroll-margin-inline-start:calc(var(--foldcn-carousel-spacing,1rem)*-1)];
-}

--- a/packages/registry/registry/default/style/cn-compat.css
+++ b/packages/registry/registry/default/style/cn-compat.css
@@ -274,3 +274,25 @@
 .cn-command-item-indicator {
   @apply size-4 shrink-0 ml-auto opacity-0 group-has-data-[slot=command-shortcut]/command-item:hidden group-data-[checked=true]/command-item:opacity-100;
 }
+
+/* carousel: the embla engine (upstream) becomes a native scroll-snap scroll
+ * port under foldkit. Upstream's viewport string is a bare "overflow-hidden";
+ * the token below carries that literal plus the scroll behaviors, so the
+ * component can reference a single token per axis without fighting cn's
+ * last-wins merge (an overflow-hidden literal after the token would strip
+ * overflow-x-auto). Slide spacing is paired (-ml-4 on the track, pl-4 on
+ * items, default 1rem) — the negative scroll margin below cancels a slide's
+ * inline/block-start padding so snap positions land on slide CONTENT, and
+ * --foldcn-carousel-spacing (set inline by the component view) keeps the
+ * pairing exact for non-default spacing like -ml-1/pl-1. */
+.cn-carousel-content {
+  @apply no-scrollbar snap-x snap-mandatory overflow-hidden overflow-x-auto overscroll-x-contain;
+}
+
+.cn-carousel-content-vertical {
+  @apply no-scrollbar snap-y snap-mandatory overflow-x-hidden overflow-y-auto overscroll-y-contain;
+}
+
+.cn-carousel-item {
+  @apply snap-start [scroll-margin-block-start:calc(var(--foldcn-carousel-spacing,1rem)*-1)] [scroll-margin-inline-start:calc(var(--foldcn-carousel-spacing,1rem)*-1)];
+}

--- a/packages/registry/registry/default/ui/carousel.ts
+++ b/packages/registry/registry/default/ui/carousel.ts
@@ -2,8 +2,13 @@
  *  Model/Message/init/update/subscriptions into your app:
  *  `import * as Carousel from '@/components/ui/carousel'`
  */
-import { Effect, Option, Schema as S } from 'effect'
+import { Effect, Option, Queue, Schema as S, Stream } from 'effect'
 import { Command, Subscription, Update } from 'foldkit'
+import EmblaCarousel, {
+  type EmblaCarouselType,
+  type EmblaOptionsType,
+  type EmblaPluginType,
+} from 'embla-carousel'
 import type { Html, HtmlBuilder } from 'foldkit/html'
 import { defineMessageUnion } from 'foldkit/message'
 import { defineView } from 'foldkit/submodel'
@@ -15,40 +20,40 @@ import { cn } from '@/lib/utils'
 
 import { button, type ButtonSize, type ButtonVariant } from './button'
 
-// A scroll-snap carousel. The model owns the selected slide index; prev/next
-// (buttons and ArrowLeft/ArrowRight anywhere inside the region) move it and
-// an ApplyScroll command smooth-scrolls the port. Native scrolling (touch
-// swipe, wheel) flows back through the contentScroll subscription, which
-// measures item geometry and reports the settled slide plus the last
-// reachable one (scrollBound) — with partial-width slides (basis-1/2…) the
-// last index is lower than count-1, exactly where the browser can scroll.
+// A carousel backed by the embla-carousel engine (the same dependency upstream
+// shadcn ships), owned by this Submodel: the scroll subscription mounts the
+// engine on the viewport when it appears in the DOM and tears it down when it
+// leaves, `select` events flow back as SelectedSlide, and Prev/Next (buttons
+// and ArrowLeft/ArrowRight anywhere inside the region) dispatch scroll
+// commands against the mounted engine. The model mirrors the upstream
+// useCarousel context values (index, canScrollPrev, canScrollNext).
 //
-// foldcn gaps vs upstream: no embla engine — no loop, align/duration opts, or
-// plugins (autoplay); no imperative API (use ChangedIndex out-messages
-// instead of setApi); RTL layouts are not handled.
-//
-// The scroll port and slide geometry are CSS-driven via the compat tokens
-// `cn-carousel-content[-vertical]` / `cn-carousel-item`: snap alignment plus
-// a negative scroll margin derived from `--foldcn-carousel-spacing` keeps
-// slide content flush with the port edges for any spacing (default 1rem,
-// matching upstream's -ml-4/pl-4 pairing).
+// foldcn deltas vs upstream: embla options are a serializable schema subset
+// carried on the model (plugins are instances and cannot live in a schema —
+// register them with `configure`); there is no setApi hand-off — listen for
+// ChangedIndex out-messages instead.
 
 export const Orientation = S.Literals(['horizontal', 'vertical'])
 export type Orientation = typeof Orientation.Type
 
+/** Serializable subset of embla's options, carried on the model so option
+ *  changes re-mount the engine with the new configuration. */
+export const Options = S.Struct({
+  align: S.optional(S.Literals(['start', 'center', 'end'])),
+  loop: S.optional(S.Boolean),
+  duration: S.optional(S.Number),
+  startIndex: S.optional(S.Number),
+  direction: S.optional(S.Literals(['ltr', 'rtl'])),
+  containScroll: S.optional(S.Literals(['trimSnaps', 'keepSnaps', false])),
+  slidesToScroll: S.optional(S.Number),
+})
+export type Options = typeof Options.Type
+
 /** Upstream Carousel root string. */
 export const carouselClass = 'relative'
 
-/** Upstream CarouselContent viewport string. Upstream's bare
- *  "overflow-hidden" is carried inside the compat token (an overflow-hidden
- *  literal after the token would strip overflow-x-auto in cn's last-wins
- *  merge — see cn-compat.css). Sizing such as a vertical height goes through
- *  viewInputs.contentClassName. */
-export const carouselContentClass = 'cn-carousel-content'
-
-/** Vertical counterpart of carouselContentClass — self-sufficient (carries
- *  its own overflow pair in the compat token). */
-export const carouselContentVerticalClass = 'cn-carousel-content-vertical'
+/** Upstream CarouselContent viewport string (embla root). */
+export const carouselContentClass = 'overflow-hidden'
 
 /** Upstream CarouselContent track strings. */
 export const carouselTrackClass = 'flex'
@@ -56,7 +61,7 @@ export const carouselTrackHorizontalClass = '-ml-4'
 export const carouselTrackVerticalClass = '-mt-4 flex-col'
 
 /** Upstream CarouselItem strings. */
-export const carouselItemClass = 'cn-carousel-item min-w-0 shrink-0 grow-0 basis-full'
+export const carouselItemClass = 'min-w-0 shrink-0 grow-0 basis-full'
 export const carouselItemHorizontalClass = 'pl-4'
 export const carouselItemVerticalClass = 'pt-4'
 
@@ -70,13 +75,30 @@ export const carouselNextClass = 'cn-carousel-next absolute touch-manipulation'
 export const carouselNextHorizontalClass = 'inset-y-0 -right-12 my-auto'
 export const carouselNextVerticalClass = '-bottom-12 left-1/2 -translate-x-1/2 rotate-90'
 
-/** DOM id of the scroll port for a carousel id. */
+/** DOM id of the embla viewport for a carousel id. */
 export const contentElementId = (id: string): string => `${id}-content`
 
-/** CSS variable the compat tokens read for slide spacing; keep it in sync
- *  with the -ml-N/pl-N spacing classes (upstream default is 1rem). */
-const SPACING_VARIABLE = '--foldcn-carousel-spacing'
-const DEFAULT_SPACING = '1rem'
+// PLUGIN / ENGINE REGISTRIES
+//
+// Embla plugin instances (autoplay, …) are stateful objects — they cannot be
+// serialized into the model, so callers register them per id before mount:
+// `Carousel.configure('my-carousel', { plugins: [Autoplay(…)] })`.
+// The mounted engine is keyed by id here: the scroll subscription writes it
+// on attach and removes it on detach, and the scroll commands read it.
+
+const pluginsById = new Map<string, EmblaPluginType[]>()
+
+export type CarouselConfiguration = Readonly<{
+  plugins?: EmblaPluginType[]
+}>
+
+/** Registers non-serializable engine configuration (plugins) for a carousel
+ *  id. Call at module scope, before the carousel mounts. */
+export const configure = (id: string, config: CarouselConfiguration): void => {
+  pluginsById.set(id, config.plugins ?? [])
+}
+
+const engineById = new Map<string, EmblaCarouselType>()
 
 // MODEL
 
@@ -85,12 +107,12 @@ export const Model = S.Struct({
   orientation: Orientation,
   /** Number of slides, matching the view's items array. */
   count: S.Number,
-  /** Selected slide index (0-based). */
+  /** Selected slide index (0-based), from embla's selectedScrollSnap. */
   index: S.Number,
-  /** Last reachable slide index — the browser cannot scroll past
-   *  scrollWidth - clientWidth, so partial-width slides stop earlier than
-   *  count - 1. Corrected by the scroll subscription's measurements. */
-  scrollBound: S.Number,
+  /** Mirrors embla's canScrollPrev/canScrollNext (always true when loop). */
+  canScrollPrev: S.Boolean,
+  canScrollNext: S.Boolean,
+  options: Options,
 })
 export type Model = typeof Model.Type
 
@@ -101,11 +123,14 @@ export const Message = defineMessageUnion({
   PressedPrevious: {},
   /** The user (or a caller) asked for the next slide. */
   PressedNext: {},
-  /** The scroll port settled near a slide (every scroll tick reports the
-   *  currently-nearest slide). */
-  ScrolledContent: { index: S.Number, scrollBound: S.Number },
-  /** ApplyScroll finished touching the DOM; nothing to do. */
-  CompletedApplyScroll: {},
+  /** The engine reported a selection change (embla select/reInit). */
+  SelectedSlide: {
+    index: S.Number,
+    canScrollPrev: S.Boolean,
+    canScrollNext: S.Boolean,
+  },
+  /** A scroll command finished touching the engine; nothing to do. */
+  CompletedScrollCommand: {},
 })
 export type Message = typeof Message.Type
 
@@ -121,30 +146,48 @@ export type InitConfig = Readonly<{
   id: string
   count: number
   orientation?: Orientation
+  /** Serializable embla options (see `Options`). Plugins go through
+   *  `configure` instead. */
+  options?: Options
 }>
 
-/** Creates an initial carousel model. */
-export const init = (config: InitConfig): Model => ({
-  id: config.id,
-  orientation: config.orientation ?? 'horizontal',
-  count: config.count,
-  index: 0,
-  scrollBound: Math.max(0, config.count - 1),
-})
+/** Creates an initial carousel model. canScroll flags start from the
+ *  configured startIndex/loop and are corrected by the engine's first
+ *  SelectedSlide. */
+export const init = (config: InitConfig): Model => {
+  const options = config.options ?? {}
+  const index = Math.min(Math.max(options.startIndex ?? 0, 0), Math.max(0, config.count - 1))
+  const loop = options.loop === true
+  return {
+    id: config.id,
+    orientation: config.orientation ?? 'horizontal',
+    count: config.count,
+    index,
+    canScrollPrev: loop || index > 0,
+    canScrollNext: loop || index < config.count - 1,
+    options,
+  }
+}
 
 type UpdateReturn = Update.ReturnWithOutMessage<Model, Message, OutMessage>
 
-const clampIndex = (value: number, bound: number): number => Math.min(Math.max(value, 0), bound)
-
-/** Moves the selection one slide toward `delta` and commands the scroll.
- *  A no-op at either end (foldkit buttons stay focusable under
- *  aria-disabled, so keyboard activation still arrives here). */
-const step = (model: Model, delta: -1 | 1): UpdateReturn => {
-  const index = clampIndex(model.index + delta, model.scrollBound)
-  if (index === model.index) return { model }
+const selected = (
+  model: Model,
+  index: number,
+  canPrev: boolean,
+  canNext: boolean,
+): UpdateReturn => {
+  if (index === model.index && canPrev === model.canScrollPrev && canNext === model.canScrollNext) {
+    return { model }
+  }
+  const next = evo(model, {
+    index: () => index,
+    canScrollPrev: () => canPrev,
+    canScrollNext: () => canNext,
+  })
+  if (index === model.index) return { model: next }
   return {
-    model: evo(model, { index: () => index }),
-    commands: [ApplyScroll({ id: model.id, index, orientation: model.orientation })],
+    model: next,
     outMessage: OutMessage.ChangedIndex({ index }),
   }
 }
@@ -154,98 +197,137 @@ const step = (model: Model, delta: -1 | 1): UpdateReturn => {
 export const update = (model: Model, message: Message): UpdateReturn => {
   switch (message._tag) {
     case 'PressedPrevious':
-      return step(model, -1)
+      return { model, commands: [ScrollPrevious({ id: model.id })] }
     case 'PressedNext':
-      return step(model, 1)
-    case 'ScrolledContent': {
-      const index = clampIndex(message.index, model.count - 1)
-      const scrollBound = clampIndex(message.scrollBound, model.count - 1)
-      if (index === model.index && scrollBound === model.scrollBound) return { model }
-      const next = evo(model, { index: () => index, scrollBound: () => scrollBound })
-      if (index === model.index) return { model: next }
-      return {
-        model: next,
-        outMessage: OutMessage.ChangedIndex({ index }),
-      }
-    }
-    case 'CompletedApplyScroll':
+      return { model, commands: [ScrollNext({ id: model.id })] }
+    case 'SelectedSlide':
+      return selected(model, message.index, message.canScrollPrev, message.canScrollNext)
+    case 'CompletedScrollCommand':
       return { model }
   }
 }
 
 // COMMANDS
 
-/** Scrolls the port so slide `index` is flush with its start edge. Stride is
- *  measured from the slide elements, so any slide basis works. */
-export const ApplyScroll = Command.define('ApplyScroll', {
-  args: { id: S.String, index: S.Number, orientation: Orientation },
-  messages: [Message.CompletedApplyScroll],
-  execute: ({ id, index, orientation }) =>
-    Effect.sync(() => {
-      const element = document.getElementById(contentElementId(id))
-      if (element === null) return Message.CompletedApplyScroll()
-      const stride = strideOf(element, orientation === 'horizontal')
-      if (stride <= 0) return Message.CompletedApplyScroll()
-      if (orientation === 'horizontal') {
-        element.scrollTo({ left: index * stride, behavior: 'smooth' })
-      } else {
-        element.scrollTo({ top: index * stride, behavior: 'smooth' })
-      }
-      return Message.CompletedApplyScroll()
-    }),
+const engineEffect = (id: string, run: (engine: EmblaCarouselType) => void) =>
+  Effect.sync(() => {
+    const engine = engineById.get(id)
+    if (engine !== undefined) run(engine)
+    return Message.CompletedScrollCommand()
+  })
+
+/** Scrolls the mounted engine one slide back/forward (no-op while the engine
+ *  is not mounted, e.g. between mount and subscription start). */
+export const ScrollPrevious = Command.define('ScrollPrevious', {
+  args: { id: S.String },
+  messages: [Message.CompletedScrollCommand],
+  execute: ({ id }) => engineEffect(id, (engine) => engine.scrollPrev()),
 })
 
-/** Distance between consecutive slide snap points: one slide's extent (the
- *  -ml-4/pl-4 pairing keeps contents exactly one offset apart). */
-const strideOf = (element: HTMLElement, isHorizontal: boolean): number => {
-  const items = element.querySelectorAll<HTMLElement>('[data-slot="carousel-item"]')
-  const first = items.item(0)
-  const second = items.item(1)
-  if (first === null) return 0
-  const extentOf = (item: HTMLElement): number => (isHorizontal ? item.offsetLeft : item.offsetTop)
-  return second === null ? extentOf(first) : extentOf(second) - extentOf(first)
-}
+export const ScrollNext = Command.define('ScrollNext', {
+  args: { id: S.String },
+  messages: [Message.CompletedScrollCommand],
+  execute: ({ id }) => engineEffect(id, (engine) => engine.scrollNext()),
+})
 
-/** Nearest slide and last reachable slide for the port's current scroll
- *  position. */
-const geometry = (element: HTMLElement, isHorizontal: boolean) => {
-  const stride = strideOf(element, isHorizontal)
-  if (stride <= 0) return { index: 0, scrollBound: 0 } as const
-  const offset = isHorizontal ? element.scrollLeft : element.scrollTop
-  const maxOffset = isHorizontal
-    ? element.scrollWidth - element.clientWidth
-    : element.scrollHeight - element.clientHeight
-  return {
-    index: Math.round(offset / stride),
-    scrollBound: Math.max(0, Math.floor(maxOffset / stride + 0.001)),
-  } as const
-}
+/** Scrolls the mounted engine to a slide; `jump` skips the animation. */
+export const ScrollTo = Command.define('ScrollTo', {
+  args: { id: S.String, index: S.Number, jump: S.optional(S.Boolean) },
+  messages: [Message.CompletedScrollCommand],
+  execute: ({ id, index, jump }) =>
+    engineEffect(id, (engine) => engine.scrollTo(index, jump === true)),
+})
 
 // SUBSCRIPTIONS
 
-/** Tracks the scroll port: a capture-phase document scroll listener (scroll
- *  events do not bubble) filtered to this carousel's port element. The port
- *  is looked up per event, so remounts across style switches or routes need
- *  no re-attachment. */
+const toEmblaOptions = (orientation: Orientation, options: Options): EmblaOptionsType => {
+  const embla: EmblaOptionsType = { axis: orientation === 'horizontal' ? 'x' : 'y' }
+  if (options.align !== undefined) embla.align = options.align
+  if (options.loop !== undefined) embla.loop = options.loop
+  if (options.duration !== undefined) embla.duration = options.duration
+  if (options.startIndex !== undefined) embla.startIndex = options.startIndex
+  if (options.direction !== undefined) embla.direction = options.direction
+  if (options.containScroll !== undefined) embla.containScroll = options.containScroll
+  if (options.slidesToScroll !== undefined) embla.slidesToScroll = options.slidesToScroll
+  return embla
+}
+
+const report = (engine: EmblaCarouselType): Message =>
+  Message.SelectedSlide({
+    index: engine.selectedScrollSnap(),
+    canScrollPrev: engine.canScrollPrev(),
+    canScrollNext: engine.canScrollNext(),
+  })
+
+/** Owns the engine's lifecycle: a MutationObserver reconciles the viewport
+ *  element (looked up by id — the element can be inserted/removed by any
+ *  parent, so route changes and style switches re-attach without consumer
+ *  help). On attach it mounts embla with the model's options and the
+ *  registered plugins and feeds select/reInit back as SelectedSlide; on
+ *  detach it destroys the engine. */
 export const subscriptions = Subscription.make<Model, Message>()((entry) => ({
-  contentScroll: entry(
-    { id: S.String, orientation: Orientation },
+  engineEvents: entry(
+    { id: S.String, orientation: Orientation, options: Options },
     {
-      modelToDependencies: (model) => ({ id: model.id, orientation: model.orientation }),
-      dependenciesToStream: ({ id, orientation }) =>
-        Subscription.fromEventFilterMap<Event, Message>({
-          target: document,
-          type: 'scroll',
-          options: { capture: true, passive: true },
-          toMessage: (event) => {
-            const target = event.target
-            if (!(target instanceof HTMLElement)) return Option.none()
-            if (target.id !== contentElementId(id)) return Option.none()
-            return Option.some(
-              Message.ScrolledContent(geometry(target, orientation === 'horizontal')),
-            )
-          },
-        }),
+      modelToDependencies: (model) => ({
+        id: model.id,
+        orientation: model.orientation,
+        options: model.options,
+      }),
+      dependenciesToStream: ({ id, orientation, options }) =>
+        Stream.callback((queue) =>
+          Effect.acquireRelease(
+            Effect.sync(() => {
+              let engine: EmblaCarouselType | undefined
+              let observer: MutationObserver | undefined
+
+              const detach = () => {
+                if (engine !== undefined) {
+                  engineById.delete(id)
+                  engine.destroy()
+                  engine = undefined
+                }
+              }
+              const attach = (element: HTMLElement) => {
+                const mounted = EmblaCarousel(
+                  element,
+                  toEmblaOptions(orientation, options),
+                  pluginsById.get(id) ?? [],
+                )
+                engineById.set(id, mounted)
+                engine = mounted
+                mounted.on('select', () => Queue.offerUnsafe(queue, report(mounted)))
+                mounted.on('reInit', () => Queue.offerUnsafe(queue, report(mounted)))
+                Queue.offerUnsafe(queue, report(mounted))
+              }
+
+              const reconcile = () => {
+                const element = document.getElementById(contentElementId(id))
+                if (element === null) {
+                  detach()
+                  return
+                }
+                if (engine !== undefined && engine.rootNode() === element) return
+                // Wait for the slides to be in the DOM before mounting.
+                if (element.querySelector('[data-slot="carousel-item"]') === null) return
+                detach()
+                attach(element)
+              }
+
+              observer = new MutationObserver(() => reconcile())
+              observer.observe(document.documentElement, { childList: true, subtree: true })
+              reconcile()
+
+              return {
+                dispose: () => {
+                  observer?.disconnect()
+                  detach()
+                },
+              }
+            }),
+            (state) => Effect.sync(() => state.dispose()),
+          ).pipe(Effect.flatMap(() => Effect.never)),
+        ),
     },
   ),
 }))
@@ -266,16 +348,10 @@ export type CarouselItemInput = Readonly<{
 export type ViewInputs = Readonly<{
   items: ReadonlyArray<CarouselItemInput>
   className?: string
-  /** Class for the scroll port (upstream CarouselContent's viewport div) —
-   *  sizing such as a vertical height belongs here. */
-  contentClassName?: string
   /** Class for the flex track (upstream CarouselContent's inner div, where
-   *  upstream puts its className) — spacing overrides like -ml-1 belong
-   *  here, kept in sync with viewInputs.spacing. */
-  trackClassName?: string
-  /** Slide spacing as a CSS length; must match the -ml-N/pl-N classes.
-   *  Drives the compat snap margin so native scrolling stays flush. */
-  spacing?: string
+   *  upstream puts its className) — spacing overrides like -ml-1 and sizing
+   *  like a vertical height belong here, exactly like upstream. */
+  contentClassName?: string
   /** Upstream renders CarouselPrevious/CarouselNext as separate parts; here
    *  they are built-in, disable with false. */
   showNavigation?: boolean
@@ -283,7 +359,7 @@ export type ViewInputs = Readonly<{
   next?: CarouselButtonConfig
 }>
 
-/** Renders the carousel region: scroll port, track, and navigation buttons.
+/** Renders the carousel region: viewport, track, and navigation buttons.
  *  Embedded via `h.submodel`. */
 export const view = defineView<Model, Message, ViewInputs>((model, viewInputs, h) => {
   const isHorizontal = model.orientation === 'horizontal'
@@ -303,14 +379,8 @@ export const view = defineView<Model, Message, ViewInputs>((model, viewInputs, h
       h.div(
         [
           h.Id(contentElementId(model.id)),
-          h.Class(
-            cn(
-              isHorizontal ? carouselContentClass : carouselContentVerticalClass,
-              viewInputs.contentClassName,
-            ),
-          ),
+          h.Class(carouselContentClass),
           h.DataAttribute('slot', 'carousel-content'),
-          h.Style({ [SPACING_VARIABLE]: viewInputs.spacing ?? DEFAULT_SPACING }),
         ],
         [
           h.div(
@@ -319,7 +389,7 @@ export const view = defineView<Model, Message, ViewInputs>((model, viewInputs, h
                 cn(
                   carouselTrackClass,
                   isHorizontal ? carouselTrackHorizontalClass : carouselTrackVerticalClass,
-                  viewInputs.trackClassName,
+                  viewInputs.contentClassName,
                 ),
               ),
             ],
@@ -368,7 +438,7 @@ const navigationButton = (
     {
       variant: config?.variant ?? 'outline',
       size: config?.size ?? 'icon-sm',
-      isDisabled: isPrevious ? model.index <= 0 : model.index >= model.scrollBound,
+      isDisabled: isPrevious ? !model.canScrollPrev : !model.canScrollNext,
       onClick: isPrevious ? Message.PressedPrevious() : Message.PressedNext(),
       className: cn(
         isPrevious ? carouselPreviousClass : carouselNextClass,

--- a/packages/registry/registry/default/ui/carousel.ts
+++ b/packages/registry/registry/default/ui/carousel.ts
@@ -1,0 +1,392 @@
+/** Stateful submodel — import the whole module as a namespace and wire its
+ *  Model/Message/init/update/subscriptions into your app:
+ *  `import * as Carousel from '@/components/ui/carousel'`
+ */
+import { Effect, Option, Schema as S } from 'effect'
+import { Command, Subscription, Update } from 'foldkit'
+import type { Html, HtmlBuilder } from 'foldkit/html'
+import { defineMessageUnion } from 'foldkit/message'
+import { defineView } from 'foldkit/submodel'
+import { evo } from 'foldkit/struct'
+
+import { icon } from '@/lib/icons'
+import { ChevronLeft, ChevronRight } from 'lucide'
+import { cn } from '@/lib/utils'
+
+import { button, type ButtonSize, type ButtonVariant } from './button'
+
+// A scroll-snap carousel. The model owns the selected slide index; prev/next
+// (buttons and ArrowLeft/ArrowRight anywhere inside the region) move it and
+// an ApplyScroll command smooth-scrolls the port. Native scrolling (touch
+// swipe, wheel) flows back through the contentScroll subscription, which
+// measures item geometry and reports the settled slide plus the last
+// reachable one (scrollBound) — with partial-width slides (basis-1/2…) the
+// last index is lower than count-1, exactly where the browser can scroll.
+//
+// foldcn gaps vs upstream: no embla engine — no loop, align/duration opts, or
+// plugins (autoplay); no imperative API (use ChangedIndex out-messages
+// instead of setApi); RTL layouts are not handled.
+//
+// The scroll port and slide geometry are CSS-driven via the compat tokens
+// `cn-carousel-content[-vertical]` / `cn-carousel-item`: snap alignment plus
+// a negative scroll margin derived from `--foldcn-carousel-spacing` keeps
+// slide content flush with the port edges for any spacing (default 1rem,
+// matching upstream's -ml-4/pl-4 pairing).
+
+export const Orientation = S.Literals(['horizontal', 'vertical'])
+export type Orientation = typeof Orientation.Type
+
+/** Upstream Carousel root string. */
+export const carouselClass = 'relative'
+
+/** Upstream CarouselContent viewport string. Upstream's bare
+ *  "overflow-hidden" is carried inside the compat token (an overflow-hidden
+ *  literal after the token would strip overflow-x-auto in cn's last-wins
+ *  merge — see cn-compat.css). Sizing such as a vertical height goes through
+ *  viewInputs.contentClassName. */
+export const carouselContentClass = 'cn-carousel-content'
+
+/** Vertical counterpart of carouselContentClass — self-sufficient (carries
+ *  its own overflow pair in the compat token). */
+export const carouselContentVerticalClass = 'cn-carousel-content-vertical'
+
+/** Upstream CarouselContent track strings. */
+export const carouselTrackClass = 'flex'
+export const carouselTrackHorizontalClass = '-ml-4'
+export const carouselTrackVerticalClass = '-mt-4 flex-col'
+
+/** Upstream CarouselItem strings. */
+export const carouselItemClass = 'cn-carousel-item min-w-0 shrink-0 grow-0 basis-full'
+export const carouselItemHorizontalClass = 'pl-4'
+export const carouselItemVerticalClass = 'pt-4'
+
+/** Upstream CarouselPrevious strings. */
+export const carouselPreviousClass = 'cn-carousel-previous absolute touch-manipulation'
+export const carouselPreviousHorizontalClass = 'inset-y-0 -left-12 my-auto'
+export const carouselPreviousVerticalClass = '-top-12 left-1/2 -translate-x-1/2 rotate-90'
+
+/** Upstream CarouselNext strings. */
+export const carouselNextClass = 'cn-carousel-next absolute touch-manipulation'
+export const carouselNextHorizontalClass = 'inset-y-0 -right-12 my-auto'
+export const carouselNextVerticalClass = '-bottom-12 left-1/2 -translate-x-1/2 rotate-90'
+
+/** DOM id of the scroll port for a carousel id. */
+export const contentElementId = (id: string): string => `${id}-content`
+
+/** CSS variable the compat tokens read for slide spacing; keep it in sync
+ *  with the -ml-N/pl-N spacing classes (upstream default is 1rem). */
+const SPACING_VARIABLE = '--foldcn-carousel-spacing'
+const DEFAULT_SPACING = '1rem'
+
+// MODEL
+
+export const Model = S.Struct({
+  id: S.String,
+  orientation: Orientation,
+  /** Number of slides, matching the view's items array. */
+  count: S.Number,
+  /** Selected slide index (0-based). */
+  index: S.Number,
+  /** Last reachable slide index — the browser cannot scroll past
+   *  scrollWidth - clientWidth, so partial-width slides stop earlier than
+   *  count - 1. Corrected by the scroll subscription's measurements. */
+  scrollBound: S.Number,
+})
+export type Model = typeof Model.Type
+
+// MESSAGES
+
+export const Message = defineMessageUnion({
+  /** The user (or a caller) asked for the previous slide. */
+  PressedPrevious: {},
+  /** The user (or a caller) asked for the next slide. */
+  PressedNext: {},
+  /** The scroll port settled near a slide (every scroll tick reports the
+   *  currently-nearest slide). */
+  ScrolledContent: { index: S.Number, scrollBound: S.Number },
+  /** ApplyScroll finished touching the DOM; nothing to do. */
+  CompletedApplyScroll: {},
+})
+export type Message = typeof Message.Type
+
+/** Emitted when the selected slide index changes. */
+export const OutMessage = defineMessageUnion({
+  ChangedIndex: { index: S.Number },
+})
+export type OutMessage = typeof OutMessage.Type
+
+// INIT / UPDATE
+
+export type InitConfig = Readonly<{
+  id: string
+  count: number
+  orientation?: Orientation
+}>
+
+/** Creates an initial carousel model. */
+export const init = (config: InitConfig): Model => ({
+  id: config.id,
+  orientation: config.orientation ?? 'horizontal',
+  count: config.count,
+  index: 0,
+  scrollBound: Math.max(0, config.count - 1),
+})
+
+type UpdateReturn = Update.ReturnWithOutMessage<Model, Message, OutMessage>
+
+const clampIndex = (value: number, bound: number): number => Math.min(Math.max(value, 0), bound)
+
+/** Moves the selection one slide toward `delta` and commands the scroll.
+ *  A no-op at either end (foldkit buttons stay focusable under
+ *  aria-disabled, so keyboard activation still arrives here). */
+const step = (model: Model, delta: -1 | 1): UpdateReturn => {
+  const index = clampIndex(model.index + delta, model.scrollBound)
+  if (index === model.index) return { model }
+  return {
+    model: evo(model, { index: () => index }),
+    commands: [ApplyScroll({ id: model.id, index, orientation: model.orientation })],
+    outMessage: OutMessage.ChangedIndex({ index }),
+  }
+}
+
+/** Processes a carousel message and returns the next model, commands, and an
+ *  optional out-message for the parent. */
+export const update = (model: Model, message: Message): UpdateReturn => {
+  switch (message._tag) {
+    case 'PressedPrevious':
+      return step(model, -1)
+    case 'PressedNext':
+      return step(model, 1)
+    case 'ScrolledContent': {
+      const index = clampIndex(message.index, model.count - 1)
+      const scrollBound = clampIndex(message.scrollBound, model.count - 1)
+      if (index === model.index && scrollBound === model.scrollBound) return { model }
+      const next = evo(model, { index: () => index, scrollBound: () => scrollBound })
+      if (index === model.index) return { model: next }
+      return {
+        model: next,
+        outMessage: OutMessage.ChangedIndex({ index }),
+      }
+    }
+    case 'CompletedApplyScroll':
+      return { model }
+  }
+}
+
+// COMMANDS
+
+/** Scrolls the port so slide `index` is flush with its start edge. Stride is
+ *  measured from the slide elements, so any slide basis works. */
+export const ApplyScroll = Command.define('ApplyScroll', {
+  args: { id: S.String, index: S.Number, orientation: Orientation },
+  messages: [Message.CompletedApplyScroll],
+  execute: ({ id, index, orientation }) =>
+    Effect.sync(() => {
+      const element = document.getElementById(contentElementId(id))
+      if (element === null) return Message.CompletedApplyScroll()
+      const stride = strideOf(element, orientation === 'horizontal')
+      if (stride <= 0) return Message.CompletedApplyScroll()
+      if (orientation === 'horizontal') {
+        element.scrollTo({ left: index * stride, behavior: 'smooth' })
+      } else {
+        element.scrollTo({ top: index * stride, behavior: 'smooth' })
+      }
+      return Message.CompletedApplyScroll()
+    }),
+})
+
+/** Distance between consecutive slide snap points: one slide's extent (the
+ *  -ml-4/pl-4 pairing keeps contents exactly one offset apart). */
+const strideOf = (element: HTMLElement, isHorizontal: boolean): number => {
+  const items = element.querySelectorAll<HTMLElement>('[data-slot="carousel-item"]')
+  const first = items.item(0)
+  const second = items.item(1)
+  if (first === null) return 0
+  const extentOf = (item: HTMLElement): number => (isHorizontal ? item.offsetLeft : item.offsetTop)
+  return second === null ? extentOf(first) : extentOf(second) - extentOf(first)
+}
+
+/** Nearest slide and last reachable slide for the port's current scroll
+ *  position. */
+const geometry = (element: HTMLElement, isHorizontal: boolean) => {
+  const stride = strideOf(element, isHorizontal)
+  if (stride <= 0) return { index: 0, scrollBound: 0 } as const
+  const offset = isHorizontal ? element.scrollLeft : element.scrollTop
+  const maxOffset = isHorizontal
+    ? element.scrollWidth - element.clientWidth
+    : element.scrollHeight - element.clientHeight
+  return {
+    index: Math.round(offset / stride),
+    scrollBound: Math.max(0, Math.floor(maxOffset / stride + 0.001)),
+  } as const
+}
+
+// SUBSCRIPTIONS
+
+/** Tracks the scroll port: a capture-phase document scroll listener (scroll
+ *  events do not bubble) filtered to this carousel's port element. The port
+ *  is looked up per event, so remounts across style switches or routes need
+ *  no re-attachment. */
+export const subscriptions = Subscription.make<Model, Message>()((entry) => ({
+  contentScroll: entry(
+    { id: S.String, orientation: Orientation },
+    {
+      modelToDependencies: (model) => ({ id: model.id, orientation: model.orientation }),
+      dependenciesToStream: ({ id, orientation }) =>
+        Subscription.fromEventFilterMap<Event, Message>({
+          target: document,
+          type: 'scroll',
+          options: { capture: true, passive: true },
+          toMessage: (event) => {
+            const target = event.target
+            if (!(target instanceof HTMLElement)) return Option.none()
+            if (target.id !== contentElementId(id)) return Option.none()
+            return Option.some(
+              Message.ScrolledContent(geometry(target, orientation === 'horizontal')),
+            )
+          },
+        }),
+    },
+  ),
+}))
+
+// VIEW
+
+export type CarouselButtonConfig = Readonly<{
+  variant?: ButtonVariant
+  size?: ButtonSize
+  className?: string
+}>
+
+export type CarouselItemInput = Readonly<{
+  content: Html | string
+  className?: string
+}>
+
+export type ViewInputs = Readonly<{
+  items: ReadonlyArray<CarouselItemInput>
+  className?: string
+  /** Class for the scroll port (upstream CarouselContent's viewport div) —
+   *  sizing such as a vertical height belongs here. */
+  contentClassName?: string
+  /** Class for the flex track (upstream CarouselContent's inner div, where
+   *  upstream puts its className) — spacing overrides like -ml-1 belong
+   *  here, kept in sync with viewInputs.spacing. */
+  trackClassName?: string
+  /** Slide spacing as a CSS length; must match the -ml-N/pl-N classes.
+   *  Drives the compat snap margin so native scrolling stays flush. */
+  spacing?: string
+  /** Upstream renders CarouselPrevious/CarouselNext as separate parts; here
+   *  they are built-in, disable with false. */
+  showNavigation?: boolean
+  previous?: CarouselButtonConfig
+  next?: CarouselButtonConfig
+}>
+
+/** Renders the carousel region: scroll port, track, and navigation buttons.
+ *  Embedded via `h.submodel`. */
+export const view = defineView<Model, Message, ViewInputs>((model, viewInputs, h) => {
+  const isHorizontal = model.orientation === 'horizontal'
+  return h.div(
+    [
+      h.Class(cn(carouselClass, viewInputs.className)),
+      h.Role('region'),
+      h.AriaRoleDescription('carousel'),
+      h.DataAttribute('slot', 'carousel'),
+      h.OnKeyDownPreventDefault((key) => {
+        if (key === 'ArrowLeft') return Option.some(Message.PressedPrevious())
+        if (key === 'ArrowRight') return Option.some(Message.PressedNext())
+        return Option.none()
+      }),
+    ],
+    [
+      h.div(
+        [
+          h.Id(contentElementId(model.id)),
+          h.Class(
+            cn(
+              isHorizontal ? carouselContentClass : carouselContentVerticalClass,
+              viewInputs.contentClassName,
+            ),
+          ),
+          h.DataAttribute('slot', 'carousel-content'),
+          h.Style({ [SPACING_VARIABLE]: viewInputs.spacing ?? DEFAULT_SPACING }),
+        ],
+        [
+          h.div(
+            [
+              h.Class(
+                cn(
+                  carouselTrackClass,
+                  isHorizontal ? carouselTrackHorizontalClass : carouselTrackVerticalClass,
+                  viewInputs.trackClassName,
+                ),
+              ),
+            ],
+            viewInputs.items.map((item) =>
+              h.div(
+                [
+                  h.Class(
+                    cn(
+                      carouselItemClass,
+                      isHorizontal ? carouselItemHorizontalClass : carouselItemVerticalClass,
+                      item.className,
+                    ),
+                  ),
+                  h.Role('group'),
+                  h.AriaRoleDescription('slide'),
+                  h.DataAttribute('slot', 'carousel-item'),
+                ],
+                [item.content],
+              ),
+            ),
+          ),
+        ],
+      ),
+      ...(viewInputs.showNavigation === false
+        ? []
+        : [
+            navigationButton(model, viewInputs, 'previous', isHorizontal, h),
+            navigationButton(model, viewInputs, 'next', isHorizontal, h),
+          ]),
+    ],
+  )
+})
+
+type NavigationDirection = 'previous' | 'next'
+
+const navigationButton = (
+  model: Model,
+  viewInputs: ViewInputs,
+  direction: NavigationDirection,
+  isHorizontal: boolean,
+  h: HtmlBuilder<Message>,
+): Html => {
+  const isPrevious = direction === 'previous'
+  const config = isPrevious ? viewInputs.previous : viewInputs.next
+  return button(
+    {
+      variant: config?.variant ?? 'outline',
+      size: config?.size ?? 'icon-sm',
+      isDisabled: isPrevious ? model.index <= 0 : model.index >= model.scrollBound,
+      onClick: isPrevious ? Message.PressedPrevious() : Message.PressedNext(),
+      className: cn(
+        isPrevious ? carouselPreviousClass : carouselNextClass,
+        isHorizontal
+          ? isPrevious
+            ? carouselPreviousHorizontalClass
+            : carouselNextHorizontalClass
+          : isPrevious
+            ? carouselPreviousVerticalClass
+            : carouselNextVerticalClass,
+        config?.className,
+      ),
+      attributes: [h.DataAttribute('slot', `carousel-${direction}`)],
+    },
+    [
+      icon(h, isPrevious ? ChevronLeft : ChevronRight, 'cn-rtl-flip'),
+      h.span([h.Class('sr-only')], [isPrevious ? 'Previous slide' : 'Next slide']),
+    ],
+    h,
+  )
+}

--- a/packages/registry/registry/default/ui/registry.json
+++ b/packages/registry/registry/default/ui/registry.json
@@ -44,7 +44,7 @@
       "name": "select",
       "type": "registry:ui",
       "title": "Select",
-      "description": "Styled custom dropdown select (single/multi) backed by the @foldkit/ui Listbox submodel — a real submodel you embed via h.submodel. For a plain native <select> helper, use native-select.",
+      "description": "Styled custom dropdown select (single/multi) backed by the @foldkit/ui Listbox submodel \u2014 a real submodel you embed via h.submodel. For a plain native <select> helper, use native-select.",
       "registryDependencies": ["@foldcn/utils", "@foldcn/icons"],
       "files": [
         {
@@ -70,20 +70,21 @@
       "name": "carousel",
       "type": "registry:ui",
       "title": "Carousel",
-      "description": "Native scroll-snap carousel with horizontal/vertical orientation, slide basis and spacing, keyboard, and programmatic control.",
+      "description": "Embla-powered carousel with orientation, slide basis/spacing, loop and align options, plugins, keyboard, and programmatic control.",
       "registryDependencies": ["@foldcn/utils", "@foldcn/button"],
       "files": [
         {
           "path": "carousel.ts",
           "type": "registry:ui"
         }
-      ]
+      ],
+      "dependencies": ["embla-carousel"]
     },
     {
       "name": "card",
       "type": "registry:ui",
       "title": "Card",
-      "description": "Composable card primitives — Card, CardHeader, CardTitle, CardDescription, CardAction, CardContent, CardFooter. A pure layout primitive.",
+      "description": "Composable card primitives \u2014 Card, CardHeader, CardTitle, CardDescription, CardAction, CardContent, CardFooter. A pure layout primitive.",
       "registryDependencies": ["@foldcn/utils"],
       "cssVars": {
         "theme": {
@@ -153,7 +154,7 @@
       "name": "dialog",
       "type": "registry:ui",
       "title": "Dialog",
-      "description": "Composable modal dialog — Dialog.header, Dialog.title, Dialog.description, Dialog.footer, Dialog.closeButton. Built on the @foldkit/ui Dialog submodel.",
+      "description": "Composable modal dialog \u2014 Dialog.header, Dialog.title, Dialog.description, Dialog.footer, Dialog.closeButton. Built on the @foldkit/ui Dialog submodel.",
       "registryDependencies": ["@foldcn/utils"],
       "cssVars": {
         "theme": {
@@ -171,7 +172,7 @@
       "name": "popover",
       "type": "registry:ui",
       "title": "Popover",
-      "description": "Composable floating panel — Popover.header, Popover.title, Popover.description. Built on the @foldkit/ui Popover submodel.",
+      "description": "Composable floating panel \u2014 Popover.header, Popover.title, Popover.description. Built on the @foldkit/ui Popover submodel.",
       "registryDependencies": ["@foldcn/utils"],
       "files": [
         {
@@ -236,7 +237,7 @@
       "name": "tabs",
       "type": "registry:ui",
       "title": "Tabs",
-      "description": "Composable tabbed interface — Tabs.list, Tabs.trigger, Tabs.content. Built on the @foldkit/ui Tabs submodel.",
+      "description": "Composable tabbed interface \u2014 Tabs.list, Tabs.trigger, Tabs.content. Built on the @foldkit/ui Tabs submodel.",
       "registryDependencies": ["@foldcn/utils"],
       "files": [
         {
@@ -301,7 +302,7 @@
       "name": "toast",
       "type": "registry:ui",
       "title": "Toast",
-      "description": "Stacked toast notifications — measured-height choreography matching Base UI: uniform collapsed stack with peek layers, hover-to-expand spread, limited visible entries, enter/exit motion, auto-dismiss and hover-pause — built on the @foldkit/ui Toast submodel (embed via h.submodel). ⚠ No swipe-to-dismiss.",
+      "description": "Stacked toast notifications \u2014 measured-height choreography matching Base UI: uniform collapsed stack with peek layers, hover-to-expand spread, limited visible entries, enter/exit motion, auto-dismiss and hover-pause \u2014 built on the @foldkit/ui Toast submodel (embed via h.submodel). \u26a0 No swipe-to-dismiss.",
       "registryDependencies": ["@foldcn/utils", "@foldcn/icons"],
       "files": [
         {
@@ -418,7 +419,7 @@
       "name": "avatar",
       "type": "registry:ui",
       "title": "Avatar",
-      "description": "Styled avatar with image, fallback, badge and grouping. Note: no automatic image error fallback — drive the swap from your own state.",
+      "description": "Styled avatar with image, fallback, badge and grouping. Note: no automatic image error fallback \u2014 drive the swap from your own state.",
       "registryDependencies": ["@foldcn/utils"],
       "files": [
         {
@@ -646,7 +647,7 @@
       "name": "context-menu",
       "type": "registry:ui",
       "title": "Context Menu",
-      "description": "Menu styled for right-click use, built on the @foldkit/ui Menu submodel. ⚠ Opens on activation at a fixed anchor, not at the pointer — foldkit has no pointer-position anchor yet.",
+      "description": "Menu styled for right-click use, built on the @foldkit/ui Menu submodel. \u26a0 Opens on activation at a fixed anchor, not at the pointer \u2014 foldkit has no pointer-position anchor yet.",
       "registryDependencies": ["@foldcn/utils"],
       "files": [
         {
@@ -659,7 +660,7 @@
       "name": "menubar",
       "type": "registry:ui",
       "title": "Menubar",
-      "description": "Horizontal bar of menus built on the @foldkit/ui Menu submodel. ⚠ Each trigger is an independent menu — no cross-menu arrow-key traversal yet.",
+      "description": "Horizontal bar of menus built on the @foldkit/ui Menu submodel. \u26a0 Each trigger is an independent menu \u2014 no cross-menu arrow-key traversal yet.",
       "registryDependencies": ["@foldcn/utils"],
       "files": [
         {
@@ -763,7 +764,7 @@
       "name": "sidebar",
       "type": "registry:ui",
       "title": "Sidebar",
-      "description": "Collapsible app shell — SidebarProvider.view submodel (offcanvas/icon/none × sidebar/floating/inset, mobile sheet, ⌘B shortcut, rail) with menu/badge/skeleton/sub-menu/input primitives.",
+      "description": "Collapsible app shell \u2014 SidebarProvider.view submodel (offcanvas/icon/none \u00d7 sidebar/floating/inset, mobile sheet, \u2318B shortcut, rail) with menu/badge/skeleton/sub-menu/input primitives.",
       "registryDependencies": ["@foldcn/utils", "@foldcn/icons"],
       "files": [
         {

--- a/packages/registry/registry/default/ui/registry.json
+++ b/packages/registry/registry/default/ui/registry.json
@@ -44,7 +44,7 @@
       "name": "select",
       "type": "registry:ui",
       "title": "Select",
-      "description": "Styled custom dropdown select (single/multi) backed by the @foldkit/ui Listbox submodel \u2014 a real submodel you embed via h.submodel. For a plain native <select> helper, use native-select.",
+      "description": "Styled custom dropdown select (single/multi) backed by the @foldkit/ui Listbox submodel — a real submodel you embed via h.submodel. For a plain native <select> helper, use native-select.",
       "registryDependencies": ["@foldcn/utils", "@foldcn/icons"],
       "files": [
         {
@@ -67,10 +67,23 @@
       ]
     },
     {
+      "name": "carousel",
+      "type": "registry:ui",
+      "title": "Carousel",
+      "description": "Native scroll-snap carousel with horizontal/vertical orientation, slide basis and spacing, keyboard, and programmatic control.",
+      "registryDependencies": ["@foldcn/utils", "@foldcn/button"],
+      "files": [
+        {
+          "path": "carousel.ts",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
       "name": "card",
       "type": "registry:ui",
       "title": "Card",
-      "description": "Composable card primitives \u2014 Card, CardHeader, CardTitle, CardDescription, CardAction, CardContent, CardFooter. A pure layout primitive.",
+      "description": "Composable card primitives — Card, CardHeader, CardTitle, CardDescription, CardAction, CardContent, CardFooter. A pure layout primitive.",
       "registryDependencies": ["@foldcn/utils"],
       "cssVars": {
         "theme": {
@@ -140,7 +153,7 @@
       "name": "dialog",
       "type": "registry:ui",
       "title": "Dialog",
-      "description": "Composable modal dialog \u2014 Dialog.header, Dialog.title, Dialog.description, Dialog.footer, Dialog.closeButton. Built on the @foldkit/ui Dialog submodel.",
+      "description": "Composable modal dialog — Dialog.header, Dialog.title, Dialog.description, Dialog.footer, Dialog.closeButton. Built on the @foldkit/ui Dialog submodel.",
       "registryDependencies": ["@foldcn/utils"],
       "cssVars": {
         "theme": {
@@ -158,7 +171,7 @@
       "name": "popover",
       "type": "registry:ui",
       "title": "Popover",
-      "description": "Composable floating panel \u2014 Popover.header, Popover.title, Popover.description. Built on the @foldkit/ui Popover submodel.",
+      "description": "Composable floating panel — Popover.header, Popover.title, Popover.description. Built on the @foldkit/ui Popover submodel.",
       "registryDependencies": ["@foldcn/utils"],
       "files": [
         {
@@ -223,7 +236,7 @@
       "name": "tabs",
       "type": "registry:ui",
       "title": "Tabs",
-      "description": "Composable tabbed interface \u2014 Tabs.list, Tabs.trigger, Tabs.content. Built on the @foldkit/ui Tabs submodel.",
+      "description": "Composable tabbed interface — Tabs.list, Tabs.trigger, Tabs.content. Built on the @foldkit/ui Tabs submodel.",
       "registryDependencies": ["@foldcn/utils"],
       "files": [
         {
@@ -288,7 +301,7 @@
       "name": "toast",
       "type": "registry:ui",
       "title": "Toast",
-      "description": "Stacked toast notifications \u2014 measured-height choreography matching Base UI: uniform collapsed stack with peek layers, hover-to-expand spread, limited visible entries, enter/exit motion, auto-dismiss and hover-pause \u2014 built on the @foldkit/ui Toast submodel (embed via h.submodel). \u26a0 No swipe-to-dismiss.",
+      "description": "Stacked toast notifications — measured-height choreography matching Base UI: uniform collapsed stack with peek layers, hover-to-expand spread, limited visible entries, enter/exit motion, auto-dismiss and hover-pause — built on the @foldkit/ui Toast submodel (embed via h.submodel). ⚠ No swipe-to-dismiss.",
       "registryDependencies": ["@foldcn/utils", "@foldcn/icons"],
       "files": [
         {
@@ -405,7 +418,7 @@
       "name": "avatar",
       "type": "registry:ui",
       "title": "Avatar",
-      "description": "Styled avatar with image, fallback, badge and grouping. Note: no automatic image error fallback \u2014 drive the swap from your own state.",
+      "description": "Styled avatar with image, fallback, badge and grouping. Note: no automatic image error fallback — drive the swap from your own state.",
       "registryDependencies": ["@foldcn/utils"],
       "files": [
         {
@@ -633,7 +646,7 @@
       "name": "context-menu",
       "type": "registry:ui",
       "title": "Context Menu",
-      "description": "Menu styled for right-click use, built on the @foldkit/ui Menu submodel. \u26a0 Opens on activation at a fixed anchor, not at the pointer \u2014 foldkit has no pointer-position anchor yet.",
+      "description": "Menu styled for right-click use, built on the @foldkit/ui Menu submodel. ⚠ Opens on activation at a fixed anchor, not at the pointer — foldkit has no pointer-position anchor yet.",
       "registryDependencies": ["@foldcn/utils"],
       "files": [
         {
@@ -646,7 +659,7 @@
       "name": "menubar",
       "type": "registry:ui",
       "title": "Menubar",
-      "description": "Horizontal bar of menus built on the @foldkit/ui Menu submodel. \u26a0 Each trigger is an independent menu \u2014 no cross-menu arrow-key traversal yet.",
+      "description": "Horizontal bar of menus built on the @foldkit/ui Menu submodel. ⚠ Each trigger is an independent menu — no cross-menu arrow-key traversal yet.",
       "registryDependencies": ["@foldcn/utils"],
       "files": [
         {
@@ -750,7 +763,7 @@
       "name": "sidebar",
       "type": "registry:ui",
       "title": "Sidebar",
-      "description": "Collapsible app shell \u2014 SidebarProvider.view submodel (offcanvas/icon/none \u00d7 sidebar/floating/inset, mobile sheet, \u2318B shortcut, rail) with menu/badge/skeleton/sub-menu/input primitives.",
+      "description": "Collapsible app shell — SidebarProvider.view submodel (offcanvas/icon/none × sidebar/floating/inset, mobile sheet, ⌘B shortcut, rail) with menu/badge/skeleton/sub-menu/input primitives.",
       "registryDependencies": ["@foldcn/utils", "@foldcn/icons"],
       "files": [
         {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -27,6 +27,8 @@
     "cn": "^0.2.4",
     "defuddle": "^0.19.3",
     "effect": "4.0.0-rc.112",
+    "embla-carousel": "^8.6.0",
+    "embla-carousel-autoplay": "^8.6.0",
     "foldkit": "^0.156.0",
     "linkedom": "^0.18.13",
     "lucide": "^1.37.0",

--- a/packages/web/src/catalog/gaps.ts
+++ b/packages/web/src/catalog/gaps.ts
@@ -37,6 +37,10 @@ export const gapsByItem = {
   'input-group': [
     'Addons do not focus the input on click — foldkit has no scoped click-to-focus primitive yet.',
   ],
+  carousel: [
+    'Native scroll-snap scroll port instead of embla — no loop, no align/duration options, and no plugins (autoplay).',
+    'No imperative API: listen for ChangedIndex out-messages instead of setApi; RTL layouts are not handled.',
+  ],
   menu: [
     'No submenu, checkbox-item, or radio-item kinds — submenus render as labelled groups and checkbox/radio rows run off demo state; toggling one closes the panel.',
   ],

--- a/packages/web/src/catalog/gaps.ts
+++ b/packages/web/src/catalog/gaps.ts
@@ -38,8 +38,8 @@ export const gapsByItem = {
     'Addons do not focus the input on click — foldkit has no scoped click-to-focus primitive yet.',
   ],
   carousel: [
-    'Native scroll-snap scroll port instead of embla — no loop, no align/duration options, and no plugins (autoplay).',
-    'No imperative API: listen for ChangedIndex out-messages instead of setApi; RTL layouts are not handled.',
+    'Embla options are a serializable schema subset on the model (align/loop/duration/startIndex/direction/containScroll/slidesToScroll); plugin instances register via Carousel.configure(id, { plugins }) since they cannot be serialized.',
+    'No imperative API hand-off: listen for ChangedIndex out-messages instead of upstream setApi.',
   ],
   menu: [
     'No submenu, checkbox-item, or radio-item kinds — submenus render as labelled groups and checkbox/radio rows run off demo state; toggling one closes the panel.',

--- a/packages/web/src/demo/assemble.ts
+++ b/packages/web/src/demo/assemble.ts
@@ -19,6 +19,7 @@ import { slice as breadcrumbSlice } from './views/breadcrumb'
 import { slice as buttonGroupSlice } from './views/button-group'
 import { slice as buttonSlice } from './views/button'
 import { slice as calendarSlice } from './views/calendar'
+import { slice as carouselSlice } from './views/carousel'
 import { slice as cardSlice } from './views/card'
 import { slice as checkboxSlice } from './views/checkbox'
 import { slice as comboboxSlice } from './views/combobox'
@@ -87,6 +88,7 @@ const ModelSchema = S.Struct({
   ...breadcrumbSlice.fields,
   ...buttonGroupSlice.fields,
   ...buttonSlice.fields,
+  ...carouselSlice.fields,
   ...calendarSlice.fields,
   ...cardSlice.fields,
   ...checkboxSlice.fields,
@@ -156,6 +158,7 @@ const MessageSchema = S.Union([
   ...breadcrumbSlice.messages,
   ...buttonGroupSlice.messages,
   ...buttonSlice.messages,
+  ...carouselSlice.messages,
   ...calendarSlice.messages,
   ...cardSlice.messages,
   ...checkboxSlice.messages,
@@ -229,6 +232,7 @@ export const init = (): DemoUpdateReturn => {
     ...breadcrumbSlice.init,
     ...buttonGroupSlice.init,
     ...buttonSlice.init,
+    ...carouselSlice.init,
     ...calendarSlice.init,
     ...cardSlice.init,
     ...checkboxSlice.init,
@@ -298,6 +302,7 @@ export const update = (model: Model, message: Message): DemoUpdateReturn => {
       ...animationSlice.handlers(model),
       ...avatarSlice.handlers(model),
       ...buttonSlice.handlers(model),
+      ...carouselSlice.handlers(model),
       ...calendarSlice.handlers(model),
       ...cardSlice.handlers(model),
       ...checkboxSlice.handlers(model),

--- a/packages/web/src/demo/examples.ts
+++ b/packages/web/src/demo/examples.ts
@@ -8,6 +8,7 @@ import avatarViewSource from './views/avatar.ts?raw'
 import badgeViewSource from './views/badge.ts?raw'
 import buttonViewSource from './views/button.ts?raw'
 import calendarViewSource from './views/calendar.ts?raw'
+import carouselViewSource from './views/carousel.ts?raw'
 import cardViewSource from './views/card.ts?raw'
 import checkboxViewSource from './views/checkbox.ts?raw'
 import comboboxViewSource from './views/combobox.ts?raw'
@@ -112,6 +113,11 @@ export const demoExampleByName: Readonly<Record<DemoItemName, DemoExample>> = {
     path: 'src/demo/views/button.ts',
     code: buttonViewSource,
     githubUrl: gh('src/demo/views/button.ts'),
+  },
+  carousel: {
+    path: 'src/demo/views/carousel.ts',
+    code: carouselViewSource,
+    githubUrl: gh('src/demo/views/carousel.ts'),
   },
   calendar: {
     path: 'src/demo/views/calendar.ts',

--- a/packages/web/src/demo/subscriptions.ts
+++ b/packages/web/src/demo/subscriptions.ts
@@ -3,6 +3,7 @@ import { Subscription } from 'foldkit'
 import { subscriptions as commandSubscriptions } from './views/command'
 
 import type { Model, Message } from './assemble'
+import { subscriptions as carouselSubscriptions } from './views/carousel'
 import { subscriptions as dragAndDropSubscriptions } from './views/drag-and-drop'
 import { subscriptions as drawerSubscriptions } from './views/drawer'
 import { subscriptions as sidebarSubscriptions } from './views/sidebar'
@@ -10,6 +11,7 @@ import { subscriptions as sliderSubscriptions } from './views/slider'
 import { subscriptions as virtualListSubscriptions } from './views/virtual-list'
 
 export const subscriptions = Subscription.aggregate<Model, Message>()(
+  carouselSubscriptions,
   commandSubscriptions,
   dragAndDropSubscriptions,
   drawerSubscriptions,

--- a/packages/web/src/demo/views/carousel.ts
+++ b/packages/web/src/demo/views/carousel.ts
@@ -1,4 +1,5 @@
 import { Update } from 'foldkit'
+import Autoplay from 'embla-carousel-autoplay'
 import { Match as M, Option } from 'effect'
 import { Schema as S } from 'effect'
 import { evo } from 'foldkit/struct'
@@ -17,6 +18,7 @@ const Message = defineMessageUnion({
   GotCarouselOrientationMessage: { message: carousel.Message },
   GotCarouselSizeMessage: { message: carousel.Message },
   GotCarouselSpacingMessage: { message: carousel.Message },
+  GotCarouselPluginMessage: { message: carousel.Message },
   GotCarouselApiMessage: { message: carousel.Message },
 })
 type CarouselMessage =
@@ -24,9 +26,17 @@ type CarouselMessage =
   | typeof Message.GotCarouselOrientationMessage.Type
   | typeof Message.GotCarouselSizeMessage.Type
   | typeof Message.GotCarouselSpacingMessage.Type
+  | typeof Message.GotCarouselPluginMessage.Type
   | typeof Message.GotCarouselApiMessage.Type
 
 const SLIDE_COUNT = 5
+
+// Plugin instances are stateful objects that cannot live in the model — the
+// upstream demo passes them as the `plugins` prop; foldcn registers them per
+// carousel id before mount.
+carousel.configure('carousel-plugin', {
+  plugins: [Autoplay({ delay: 2000, stopOnInteraction: true })],
+})
 
 // Upstream demos wrap each card in a p-1 div and size the number per example;
 // the spacing example drops the wrapper (its pl-1 IS the spacing) and uses
@@ -70,10 +80,29 @@ const section = (label: string, content: Html, h: HtmlBuilder<AppMessage>): Html
   )
 
 // Spacing notes per example (mirrors the upstream demos): the track's -ml-N
-// and each item's pl-N pair with the carousel's `spacing` value so snap
-// positions stay on slide content — 1rem with the default -ml-4/pl-4,
-// 0.25rem with the -ml-1/pl-1 examples. The vertical example's height lives
-// on the scroll port (contentClassName), not the track.
+// and each item's pl-N pair so slide content stays flush — embla handles the
+// spacing natively, exactly like upstream.
+
+const embed = (
+  id:
+    | 'carousel'
+    | 'carouselOrientation'
+    | 'carouselSize'
+    | 'carouselSpacing'
+    | 'carouselPlugin'
+    | 'carouselApi',
+  model: Model,
+  viewInputs: carousel.ViewInputs,
+  toParentMessage: (message: carousel.Message) => CarouselMessage,
+  h: HtmlBuilder<AppMessage>,
+): Html =>
+  h.submodel({
+    slotId: model[id].id,
+    model: model[id],
+    view: carousel.view,
+    viewInputs,
+    toParentMessage,
+  })
 
 export const carouselView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
   h.div(
@@ -84,13 +113,13 @@ export const carouselView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
         h.div(
           [h.Class('w-full max-w-xs')],
           [
-            h.submodel({
-              slotId: model.carousel.id,
-              model: model.carousel,
-              view: carousel.view,
-              viewInputs: { items: slides(SLIDE_COUNT, {}, h) },
-              toParentMessage: (message) => Message.GotCarouselMessage({ message }),
-            }),
+            embed(
+              'carousel',
+              model,
+              { items: slides(SLIDE_COUNT, {}, h) },
+              (message) => Message.GotCarouselMessage({ message }),
+              h,
+            ),
           ],
         ),
         h,
@@ -100,18 +129,16 @@ export const carouselView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
         h.div(
           [h.Class('w-full max-w-xs')],
           [
-            h.submodel({
-              slotId: model.carouselOrientation.id,
-              model: model.carouselOrientation,
-              view: carousel.view,
-              viewInputs: {
+            embed(
+              'carouselOrientation',
+              model,
+              {
                 items: slides(SLIDE_COUNT, { itemClass: 'pt-1 md:basis-1/2' }, h),
-                contentClassName: 'h-[200px]',
-                trackClassName: '-mt-1',
-                spacing: '0.25rem',
+                contentClassName: '-mt-1 h-[200px]',
               },
-              toParentMessage: (message) => Message.GotCarouselOrientationMessage({ message }),
-            }),
+              (message) => Message.GotCarouselOrientationMessage({ message }),
+              h,
+            ),
           ],
         ),
         h,
@@ -121,15 +148,15 @@ export const carouselView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
         h.div(
           [h.Class('w-full max-w-sm')],
           [
-            h.submodel({
-              slotId: model.carouselSize.id,
-              model: model.carouselSize,
-              view: carousel.view,
-              viewInputs: {
+            embed(
+              'carouselSize',
+              model,
+              {
                 items: slides(SLIDE_COUNT, { itemClass: 'md:basis-1/2 lg:basis-1/3' }, h),
               },
-              toParentMessage: (message) => Message.GotCarouselSizeMessage({ message }),
-            }),
+              (message) => Message.GotCarouselSizeMessage({ message }),
+              h,
+            ),
           ],
         ),
         h,
@@ -139,11 +166,10 @@ export const carouselView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
         h.div(
           [h.Class('w-full max-w-sm')],
           [
-            h.submodel({
-              slotId: model.carouselSpacing.id,
-              model: model.carouselSpacing,
-              view: carousel.view,
-              viewInputs: {
+            embed(
+              'carouselSpacing',
+              model,
+              {
                 items: slides(
                   SLIDE_COUNT,
                   {
@@ -153,11 +179,27 @@ export const carouselView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
                   },
                   h,
                 ),
-                trackClassName: '-ml-1',
-                spacing: '0.25rem',
+                contentClassName: '-ml-1',
               },
-              toParentMessage: (message) => Message.GotCarouselSpacingMessage({ message }),
-            }),
+              (message) => Message.GotCarouselSpacingMessage({ message }),
+              h,
+            ),
+          ],
+        ),
+        h,
+      ),
+      section(
+        'Plugin',
+        h.div(
+          [h.Class('w-full max-w-xs')],
+          [
+            embed(
+              'carouselPlugin',
+              model,
+              { items: slides(SLIDE_COUNT, {}, h) },
+              (message) => Message.GotCarouselPluginMessage({ message }),
+              h,
+            ),
           ],
         ),
         h,
@@ -167,13 +209,13 @@ export const carouselView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
         h.div(
           [h.Class('mx-auto w-full max-w-xs')],
           [
-            h.submodel({
-              slotId: model.carouselApi.id,
-              model: model.carouselApi,
-              view: carousel.view,
-              viewInputs: { items: slides(SLIDE_COUNT, {}, h) },
-              toParentMessage: (message) => Message.GotCarouselApiMessage({ message }),
-            }),
+            embed(
+              'carouselApi',
+              model,
+              { items: slides(SLIDE_COUNT, {}, h) },
+              (message) => Message.GotCarouselApiMessage({ message }),
+              h,
+            ),
             h.div(
               [h.Class('py-2 text-center text-sm text-muted-foreground')],
               [`Slide ${model.carouselApiIndex + 1} of ${model.carouselApi.count}`],
@@ -226,6 +268,7 @@ const fields = {
   carouselOrientation: carousel.Model,
   carouselSize: carousel.Model,
   carouselSpacing: carousel.Model,
+  carouselPlugin: carousel.Model,
   carouselApi: carousel.Model,
   carouselApiIndex: S.Number,
 }
@@ -239,12 +282,12 @@ const liftCarouselSubscriptions = (
   toParentMessage: (message: carousel.Message) => CarouselMessage,
 ) => {
   const lifted = Subscription.lift({
-    contentScroll: carousel.subscriptions.contentScroll,
+    engineEvents: carousel.subscriptions.engineEvents,
   })<State, CarouselMessage>({
     toChildModel: read,
     toParentMessage,
   })
-  return { [`${name}ContentScroll`]: lifted.contentScroll }
+  return { [`${name}EngineEvents`]: lifted.engineEvents }
 }
 
 export const subscriptions = Subscription.aggregate<State, CarouselMessage>()(
@@ -269,6 +312,11 @@ export const subscriptions = Subscription.aggregate<State, CarouselMessage>()(
     (message) => Message.GotCarouselSpacingMessage({ message }),
   ),
   liftCarouselSubscriptions(
+    'carouselPlugin',
+    (model) => model.carouselPlugin,
+    (message) => Message.GotCarouselPluginMessage({ message }),
+  ),
+  liftCarouselSubscriptions(
     'carouselApi',
     (model) => model.carouselApi,
     (message) => Message.GotCarouselApiMessage({ message }),
@@ -283,9 +331,19 @@ export const slice = defineSlice({
       id: 'carousel-orientation',
       count: SLIDE_COUNT,
       orientation: 'vertical',
+      options: { align: 'start' },
     }),
-    carouselSize: carousel.init({ id: 'carousel-size', count: SLIDE_COUNT }),
-    carouselSpacing: carousel.init({ id: 'carousel-spacing', count: SLIDE_COUNT }),
+    carouselSize: carousel.init({
+      id: 'carousel-size',
+      count: SLIDE_COUNT,
+      options: { align: 'start' },
+    }),
+    carouselSpacing: carousel.init({
+      id: 'carousel-spacing',
+      count: SLIDE_COUNT,
+      options: { align: 'start' },
+    }),
+    carouselPlugin: carousel.init({ id: 'carousel-plugin', count: SLIDE_COUNT }),
     carouselApi: carousel.init({ id: 'carousel-api', count: SLIDE_COUNT }),
     carouselApiIndex: 0,
   },
@@ -294,6 +352,7 @@ export const slice = defineSlice({
     Message.GotCarouselOrientationMessage,
     Message.GotCarouselSizeMessage,
     Message.GotCarouselSpacingMessage,
+    Message.GotCarouselPluginMessage,
     Message.GotCarouselApiMessage,
   ],
   handlers: (model: State) => ({
@@ -325,6 +384,14 @@ export const slice = defineSlice({
         (model, next) => evo(model, { carouselSpacing: () => next }),
         (message) => Message.GotCarouselSpacingMessage({ message }),
       )(model, payload.message),
+    GotCarouselPluginMessage: (
+      payload: typeof Message.GotCarouselPluginMessage.Type,
+    ): UpdateReturn =>
+      foldCarousel(
+        (model) => model.carouselPlugin,
+        (model, next) => evo(model, { carouselPlugin: () => next }),
+        (message) => Message.GotCarouselPluginMessage({ message }),
+      )(model, payload.message),
     GotCarouselApiMessage: (payload: typeof Message.GotCarouselApiMessage.Type): UpdateReturn =>
       Update.foldChild({
         update: carousel.update,
@@ -336,7 +403,11 @@ export const slice = defineSlice({
   }),
   samples: [
     Message.GotCarouselMessage({
-      message: carousel.Message.ScrolledContent({ index: 1, scrollBound: 4 }),
+      message: carousel.Message.SelectedSlide({
+        index: 1,
+        canScrollPrev: true,
+        canScrollNext: true,
+      }),
     }),
   ],
   subscriptions,

--- a/packages/web/src/demo/views/carousel.ts
+++ b/packages/web/src/demo/views/carousel.ts
@@ -1,0 +1,343 @@
+import { Update } from 'foldkit'
+import { Match as M, Option } from 'effect'
+import { Schema as S } from 'effect'
+import { evo } from 'foldkit/struct'
+import { defineMessageUnion } from 'foldkit/message'
+import type { Html, HtmlBuilder } from 'foldkit/html'
+import { Subscription } from 'foldkit'
+
+import * as carousel from '../../generated/registry/ui/carousel'
+import { Card } from '../../generated/registry/ui/card'
+
+import { defineSlice, type UpdateReturn } from '../slice'
+import type { Model, Message as AppMessage } from '../assemble'
+
+const Message = defineMessageUnion({
+  GotCarouselMessage: { message: carousel.Message },
+  GotCarouselOrientationMessage: { message: carousel.Message },
+  GotCarouselSizeMessage: { message: carousel.Message },
+  GotCarouselSpacingMessage: { message: carousel.Message },
+  GotCarouselApiMessage: { message: carousel.Message },
+})
+type CarouselMessage =
+  | typeof Message.GotCarouselMessage.Type
+  | typeof Message.GotCarouselOrientationMessage.Type
+  | typeof Message.GotCarouselSizeMessage.Type
+  | typeof Message.GotCarouselSpacingMessage.Type
+  | typeof Message.GotCarouselApiMessage.Type
+
+const SLIDE_COUNT = 5
+
+// Upstream demos wrap each card in a p-1 div and size the number per example;
+// the spacing example drops the wrapper (its pl-1 IS the spacing) and uses
+// text-2xl.
+const slide = (
+  n: number,
+  config: Readonly<{ wrapperClass?: string; numberClass?: string }>,
+  h: HtmlBuilder<AppMessage>,
+): Html => {
+  const card = Card<AppMessage>(
+    {},
+    [
+      Card.content<AppMessage>(
+        { className: 'flex aspect-square items-center justify-center p-6' },
+        [h.span([h.Class(config.numberClass ?? 'text-4xl font-semibold')], [String(n)])],
+        h,
+      ),
+    ],
+    h,
+  )
+  if (config.wrapperClass === undefined) return h.div([h.Class('p-1')], [card])
+  if (config.wrapperClass === '') return card
+  return h.div([h.Class(config.wrapperClass)], [card])
+}
+
+const slides = (
+  count: number,
+  config: Readonly<{ wrapperClass?: string; numberClass?: string; itemClass?: string }>,
+  h: HtmlBuilder<AppMessage>,
+): carousel.CarouselItemInput[] =>
+  Array.from({ length: count }, (_, index) => {
+    const item: carousel.CarouselItemInput = { content: slide(index + 1, config, h) }
+    if (config.itemClass !== undefined) return { ...item, className: config.itemClass }
+    return item
+  })
+
+const section = (label: string, content: Html, h: HtmlBuilder<AppMessage>): Html =>
+  h.div(
+    [h.Class('flex w-full flex-col gap-2')],
+    [h.div([h.Class('px-1 text-xs font-medium text-muted-foreground')], [label]), content],
+  )
+
+// Spacing notes per example (mirrors the upstream demos): the track's -ml-N
+// and each item's pl-N pair with the carousel's `spacing` value so snap
+// positions stay on slide content — 1rem with the default -ml-4/pl-4,
+// 0.25rem with the -ml-1/pl-1 examples. The vertical example's height lives
+// on the scroll port (contentClassName), not the track.
+
+export const carouselView = (model: Model, h: HtmlBuilder<AppMessage>): Html =>
+  h.div(
+    [h.Class('flex w-full flex-col gap-8')],
+    [
+      section(
+        'Demo',
+        h.div(
+          [h.Class('w-full max-w-xs')],
+          [
+            h.submodel({
+              slotId: model.carousel.id,
+              model: model.carousel,
+              view: carousel.view,
+              viewInputs: { items: slides(SLIDE_COUNT, {}, h) },
+              toParentMessage: (message) => Message.GotCarouselMessage({ message }),
+            }),
+          ],
+        ),
+        h,
+      ),
+      section(
+        'Orientation',
+        h.div(
+          [h.Class('w-full max-w-xs')],
+          [
+            h.submodel({
+              slotId: model.carouselOrientation.id,
+              model: model.carouselOrientation,
+              view: carousel.view,
+              viewInputs: {
+                items: slides(SLIDE_COUNT, { itemClass: 'pt-1 md:basis-1/2' }, h),
+                contentClassName: 'h-[200px]',
+                trackClassName: '-mt-1',
+                spacing: '0.25rem',
+              },
+              toParentMessage: (message) => Message.GotCarouselOrientationMessage({ message }),
+            }),
+          ],
+        ),
+        h,
+      ),
+      section(
+        'Size',
+        h.div(
+          [h.Class('w-full max-w-sm')],
+          [
+            h.submodel({
+              slotId: model.carouselSize.id,
+              model: model.carouselSize,
+              view: carousel.view,
+              viewInputs: {
+                items: slides(SLIDE_COUNT, { itemClass: 'md:basis-1/2 lg:basis-1/3' }, h),
+              },
+              toParentMessage: (message) => Message.GotCarouselSizeMessage({ message }),
+            }),
+          ],
+        ),
+        h,
+      ),
+      section(
+        'Spacing',
+        h.div(
+          [h.Class('w-full max-w-sm')],
+          [
+            h.submodel({
+              slotId: model.carouselSpacing.id,
+              model: model.carouselSpacing,
+              view: carousel.view,
+              viewInputs: {
+                items: slides(
+                  SLIDE_COUNT,
+                  {
+                    wrapperClass: '',
+                    numberClass: 'text-2xl font-semibold',
+                    itemClass: 'pl-1 md:basis-1/2 lg:basis-1/3',
+                  },
+                  h,
+                ),
+                trackClassName: '-ml-1',
+                spacing: '0.25rem',
+              },
+              toParentMessage: (message) => Message.GotCarouselSpacingMessage({ message }),
+            }),
+          ],
+        ),
+        h,
+      ),
+      section(
+        'API',
+        h.div(
+          [h.Class('mx-auto w-full max-w-xs')],
+          [
+            h.submodel({
+              slotId: model.carouselApi.id,
+              model: model.carouselApi,
+              view: carousel.view,
+              viewInputs: { items: slides(SLIDE_COUNT, {}, h) },
+              toParentMessage: (message) => Message.GotCarouselApiMessage({ message }),
+            }),
+            h.div(
+              [h.Class('py-2 text-center text-sm text-muted-foreground')],
+              [`Slide ${model.carouselApiIndex + 1} of ${model.carouselApi.count}`],
+            ),
+          ],
+        ),
+        h,
+      ),
+    ],
+  )
+
+const foldNoOp =
+  <Out>(): ((out: Out) => Update.Step<State, unknown>) =>
+  () =>
+  (model) => ({ model })
+
+const foldCarouselOutMessage = M.type<carousel.OutMessage>().pipe(
+  M.withReturnType<Update.Step<State, unknown>>(),
+  M.tagsExhaustive({
+    ChangedIndex: foldNoOp(),
+  }),
+)
+
+const foldCarouselOutMessageApi = M.type<carousel.OutMessage>().pipe(
+  M.withReturnType<Update.Step<State, unknown>>(),
+  M.tagsExhaustive({
+    ChangedIndex:
+      ({ index }) =>
+      (model: State) => ({
+        model: evo(model, { carouselApiIndex: () => index }),
+      }),
+  }),
+)
+
+const foldCarousel = (
+  read: (model: State) => carousel.Model,
+  write: (model: State, next: carousel.Model) => State,
+  toParentMessage: (message: carousel.Message) => CarouselMessage,
+) =>
+  Update.foldChild({
+    update: carousel.update,
+    read: (model: State) => Option.some(read(model)),
+    write,
+    toParentMessage,
+    foldOutMessage: foldCarouselOutMessage,
+  })
+
+const fields = {
+  carousel: carousel.Model,
+  carouselOrientation: carousel.Model,
+  carouselSize: carousel.Model,
+  carouselSpacing: carousel.Model,
+  carouselApi: carousel.Model,
+  carouselApiIndex: S.Number,
+}
+
+const stateSchema = S.Struct(fields)
+type State = typeof stateSchema.Type
+
+const liftCarouselSubscriptions = (
+  name: string,
+  read: (model: State) => carousel.Model,
+  toParentMessage: (message: carousel.Message) => CarouselMessage,
+) => {
+  const lifted = Subscription.lift({
+    contentScroll: carousel.subscriptions.contentScroll,
+  })<State, CarouselMessage>({
+    toChildModel: read,
+    toParentMessage,
+  })
+  return { [`${name}ContentScroll`]: lifted.contentScroll }
+}
+
+export const subscriptions = Subscription.aggregate<State, CarouselMessage>()(
+  liftCarouselSubscriptions(
+    'carousel',
+    (model) => model.carousel,
+    (message) => Message.GotCarouselMessage({ message }),
+  ),
+  liftCarouselSubscriptions(
+    'carouselOrientation',
+    (model) => model.carouselOrientation,
+    (message) => Message.GotCarouselOrientationMessage({ message }),
+  ),
+  liftCarouselSubscriptions(
+    'carouselSize',
+    (model) => model.carouselSize,
+    (message) => Message.GotCarouselSizeMessage({ message }),
+  ),
+  liftCarouselSubscriptions(
+    'carouselSpacing',
+    (model) => model.carouselSpacing,
+    (message) => Message.GotCarouselSpacingMessage({ message }),
+  ),
+  liftCarouselSubscriptions(
+    'carouselApi',
+    (model) => model.carouselApi,
+    (message) => Message.GotCarouselApiMessage({ message }),
+  ),
+)
+
+export const slice = defineSlice({
+  fields,
+  init: {
+    carousel: carousel.init({ id: 'carousel-demo', count: SLIDE_COUNT }),
+    carouselOrientation: carousel.init({
+      id: 'carousel-orientation',
+      count: SLIDE_COUNT,
+      orientation: 'vertical',
+    }),
+    carouselSize: carousel.init({ id: 'carousel-size', count: SLIDE_COUNT }),
+    carouselSpacing: carousel.init({ id: 'carousel-spacing', count: SLIDE_COUNT }),
+    carouselApi: carousel.init({ id: 'carousel-api', count: SLIDE_COUNT }),
+    carouselApiIndex: 0,
+  },
+  messages: [
+    Message.GotCarouselMessage,
+    Message.GotCarouselOrientationMessage,
+    Message.GotCarouselSizeMessage,
+    Message.GotCarouselSpacingMessage,
+    Message.GotCarouselApiMessage,
+  ],
+  handlers: (model: State) => ({
+    GotCarouselMessage: (payload: typeof Message.GotCarouselMessage.Type): UpdateReturn =>
+      foldCarousel(
+        (model) => model.carousel,
+        (model, next) => evo(model, { carousel: () => next }),
+        (message) => Message.GotCarouselMessage({ message }),
+      )(model, payload.message),
+    GotCarouselOrientationMessage: (
+      payload: typeof Message.GotCarouselOrientationMessage.Type,
+    ): UpdateReturn =>
+      foldCarousel(
+        (model) => model.carouselOrientation,
+        (model, next) => evo(model, { carouselOrientation: () => next }),
+        (message) => Message.GotCarouselOrientationMessage({ message }),
+      )(model, payload.message),
+    GotCarouselSizeMessage: (payload: typeof Message.GotCarouselSizeMessage.Type): UpdateReturn =>
+      foldCarousel(
+        (model) => model.carouselSize,
+        (model, next) => evo(model, { carouselSize: () => next }),
+        (message) => Message.GotCarouselSizeMessage({ message }),
+      )(model, payload.message),
+    GotCarouselSpacingMessage: (
+      payload: typeof Message.GotCarouselSpacingMessage.Type,
+    ): UpdateReturn =>
+      foldCarousel(
+        (model) => model.carouselSpacing,
+        (model, next) => evo(model, { carouselSpacing: () => next }),
+        (message) => Message.GotCarouselSpacingMessage({ message }),
+      )(model, payload.message),
+    GotCarouselApiMessage: (payload: typeof Message.GotCarouselApiMessage.Type): UpdateReturn =>
+      Update.foldChild({
+        update: carousel.update,
+        read: (model: State) => Option.some(model.carouselApi),
+        write: (model, next) => evo(model, { carouselApi: () => next }),
+        toParentMessage: (message) => Message.GotCarouselApiMessage({ message }),
+        foldOutMessage: foldCarouselOutMessageApi,
+      })(model, payload.message),
+  }),
+  samples: [
+    Message.GotCarouselMessage({
+      message: carousel.Message.ScrolledContent({ index: 1, scrollBound: 4 }),
+    }),
+  ],
+  subscriptions,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       effect:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
+      embla-carousel:
+        specifier: ^8.6.0
+        version: 8.6.0
       foldkit:
         specifier: ^0.156.0
         version: 0.156.0(effect@4.0.0-rc.112)
@@ -101,6 +104,12 @@ importers:
       effect:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
+      embla-carousel:
+        specifier: ^8.6.0
+        version: 8.6.0
+      embla-carousel-autoplay:
+        specifier: ^8.6.0
+        version: 8.6.0(embla-carousel@8.6.0)
       foldkit:
         specifier: ^0.156.0
         version: 0.156.0(effect@4.0.0-rc.112)
@@ -2517,6 +2526,14 @@ packages:
 
   effect@4.0.0-rc.112:
     resolution: {integrity: sha512-wXxwuh1Ywnv4cPRM3Wfa0vDwuOHnZ1TsTgHJkG9XgzND6inhBH9n1vBxhg3iIXOia/OrpmvVmd3lrD4vq6bF3A==}
+
+  embla-carousel-autoplay@8.6.0:
+    resolution: {integrity: sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==}
+    peerDependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel@8.6.0:
+    resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -5412,6 +5429,12 @@ snapshots:
     dependencies:
       fast-check: 4.9.0
       msgpackr: 2.1.0
+
+  embla-carousel-autoplay@8.6.0(embla-carousel@8.6.0):
+    dependencies:
+      embla-carousel: 8.6.0
+
+  embla-carousel@8.6.0: {}
 
   emoji-regex@10.6.0: {}
 


### PR DESCRIPTION
# Port carousel from upstream base registry

Ports the upstream shadcn `carousel` (`apps/v4/registry/bases/base/ui/carousel.tsx`) to foldcn per `docs/deriving-from-base.md` (ADR-014): upstream `cn-*` class strings, foldkit deltas in `cn-compat.css`. Two commits:

1. `367c303` — initial port as a native scroll-snap submodel (no embla dependency).
2. `2073986` — swaps the engine for **embla-carousel 8.6.0** (vanilla, zero-dependency — the same engine upstream ships via `embla-carousel-react`), reaching upstream feature parity. Commit 1 is kept for the record; the review target is the tree at HEAD.

## Architecture

Stateful submodel (`Model`/`Message`/`update`/`view`/`subscriptions`), embed via `h.submodel`:

- **Model** mirrors upstream's `useCarousel` context: `{ id, orientation, count, index, canScrollPrev, canScrollNext, options }`.
- **Engine lifecycle** — the `engineEvents` subscription owns embla: a MutationObserver (virtual-list precedent) mounts `EmblaCarousel(viewport, options, plugins)` when the viewport element *and its slides* appear in the DOM, destroys it on detach, and re-attaches across route changes / style switches with no consumer help. `select`/`reInit` flow back as `SelectedSlide { index, canScrollPrev, canScrollNext }` → `ChangedIndex` out-messages (the foldkit answer to `setApi`).
- **Scroll commands** — `ScrollPrevious` / `ScrollNext` / `ScrollTo` read the mounted engine from an id-keyed registry (written at attach, cleared at detach). `PressedPrevious`/`PressedNext` (buttons + ArrowLeft/ArrowRight anywhere in the region via `OnKeyDownPreventDefault`) dispatch them. Commands are the sanctioned side-effect site (virtual-list `ApplyScroll` precedent); update stays pure.
- **Options** — a serializable schema subset carried **on the model** (`align`, `loop`, `duration`, `startIndex`, `direction`, `containScroll`, `slidesToScroll`); changing them re-mounts the engine with the new config. Plugin instances (autoplay, …) are stateful objects that cannot live in a schema, so callers register them per id: `Carousel.configure(id, { plugins: [Autoplay(…)] })` at module scope.
- **View** — fully upstream-verbatim strings: root `relative` + `role="region"`/`aria-roledescription="carousel"`, viewport `overflow-hidden` (embla root, `data-slot="carousel-content"`), track `flex -ml-4`/`-mt-4 flex-col` (+ `contentClassName` at upstream's CarouselContent position), items `min-w-0 shrink-0 grow-0 basis-full pl-4`/`pt-4` + slide roles, built-in prev/next buttons (`outline`/`icon-sm`, `cn-carousel-previous/next` tokens, `cn-rtl-flip` icons, `sr-only` labels). embla owns all scroll behavior, so the first commit's snap-margin compat tokens and spacing variable are **deleted** — the compat CSS carries nothing carousel-specific.

## Why embla

Commit 1's native scroll-snap port worked but hand-rolled the geometry (measured stride, negative scroll-margin paired to `-ml-N/pl-N`, reachable-bound tracking) and could not support loop, align, duration, plugins, or RTL. Embla's core is framework-agnostic vanilla JS with no dependencies, so adapting it closes all of that:

- upstream gaps that **closed**: loop, `align`/`duration`/`startIndex`, plugins (autoplay), RTL (`direction`), non-uniform slide widths;
- DOM-safety verified at the source level: foldkit's snabbdom style patcher only touches properties declared in vnode style data (`foldkit/dist/snabbdom/style.js` — `if (!oldStyle && !style) return`), and the embla container/slides declare none, so embla's inline transforms survive every foldkit re-render (confirmed live, including autoplay mid-cycle across a style switch);
- hydration/SSG: embla mounts client-side after hydration — same pre-init flash as upstream React.

## Files

| File | Change |
|---|---|
| `packages/registry/registry/default/ui/carousel.ts` | new — embla-backed submodel |
| `packages/registry/registry/default/style/cn-compat.css` | net-zero carousel delta (tokens added in commit 1, removed in commit 2); vendored `style-*.css` untouched |
| `packages/registry/registry/default/ui/registry.json` | + `carousel` item; deps `embla-carousel` (+ base `@foldcn/utils`, `@foldcn/button`) |
| `packages/registry/package.json`, `packages/web/package.json`, `pnpm-lock.yaml` | + `embla-carousel` ^8.6.0 (web also `embla-carousel-autoplay` for the demo) |
| `packages/web/src/demo/views/carousel.ts` | 6 examples mirroring upstream demos (Demo, Orientation, Size, Spacing, Plugin/autoplay, API) + 6 lifted engine-event subscriptions |
| `packages/web/src/demo/assemble.ts`, `subscriptions.ts`, `examples.ts` | wire the slice |
| `packages/web/src/catalog/gaps.ts` | carousel entry: options subset + `configure` for plugins, no `setApi` hand-off |

## Documented gaps (`catalog/gaps.ts`)

- Embla options are a serializable schema subset on the model; plugin instances register via `Carousel.configure(id, { plugins })`.
- No imperative API hand-off: `ChangedIndex` out-messages instead of upstream `setApi`.

Everything else matches upstream: loop, align/duration/startIndex, RTL, plugins, drag/swipe, keyboard, non-uniform bases. The upstream demo's `onMouseEnter`/`onMouseLeave` autoplay pause is caller-owned plugin behavior and is not demoed.

## Verification

- `pnpm --filter @foldcn/registry run build` ✓ (69 items × 8 styles), `validate` ✓, `pnpm typecheck` ✓, `pnpm lint` ✓, `pnpm test` 39/39 ✓, web build ✓ (SSG emits `/docs/carousel`).
- Resolve warnings for `cn-carousel-previous`/`cn-carousel-next` on lyra/sera mirror upstream (those styles define no carousel tokens).
- In-browser, per instance:
  - Engine mounted on all six carousels (embla `translate3d` on the track).
  - Next/Prev via commands: transforms move with slide content **flush at 0 px** in every spacing/basis combination (`-ml-4/pl-4` stride 336 px; `basis-1/2`/`1/3` stride 133 px; `-ml-1/pl-1` stride 129 px; vertical axis `translate3d(0, -356px, 0)` with `align: 'start'`).
  - `select` → `SelectedSlide` → model → button disabled states flip correctly at both ends; API demo counter tracks "Slide X of 5".
  - Autoplay plugin rotates the Plugin example continuously (wraps at the end, embla autoplay default) and survives re-renders.
  - Keyboard ArrowRight with focus inside the region advances the carousel.
  - Style switch (default ↔ nova): engines stay mounted and state-consistent.

## Notes for review

- `init` derives optimistic `canScrollPrev/Next` from `startIndex`/`loop`; the engine's first `SelectedSlide` corrects them.
- Remounts conform the model to the engine's state (`SelectedSlide` on attach) — after a remount the carousel reads fresh (`startIndex`), the world-is-source-of-truth convention.
- The demo's Plugin example omits upstream's mouse-enter/leave pause (plugin-method calls from view events; caller-owned upstream too).
